### PR TITLE
`load_dotenv()` added in `src/ui/app.py` in order to load from `.env` file

### DIFF
--- a/src/colette/ui/app.py
+++ b/src/colette/ui/app.py
@@ -1,5 +1,6 @@
 import argparse
 from pathlib import Path
+from dotenv import load_dotenv
 
 import gradio as gr
 from gradio_i18n import Translate
@@ -22,6 +23,9 @@ from colette.ui.utils.logger import log_file, logger
 from colette.ui.utils.namesgenerator import get_random_name
 
 ASSETS_DIR = Path(__file__).parent / "assets"
+
+# Load .env if it exists
+load_dotenv()
 
 def create_gradio_interface(config_path):
     # Initialize configuration and applications


### PR DESCRIPTION
This change adds `load_dotenv()` in `src/ui/app.py` to load environment variables from the `.env` file, enabling the app to access them via `os.getenv()`.