### PR TITLE
chore(docker): flash attn source build when building docker image with cuda 12.6

### DIFF
--- a/docker/gpu_build.Dockerfile
+++ b/docker/gpu_build.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.5.1-devel-ubuntu22.04 AS colette_gpu
+FROM nvidia/cuda:12.6.0-devel-ubuntu22.04 AS colette_gpu_build
 
 LABEL description="LLM application API"
 LABEL maintainer="contact@jolibrain.com"
@@ -32,6 +32,7 @@ ADD pyproject.toml .
 ADD . /app
 RUN python3 -m pip install --upgrade pip
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip pip install torch==2.6.0
-RUN --mount=type=cache,mode=0755,target=/root/.cache/pip pip install flash-attn --no-build-isolation
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip pip3 install -e .[dev,trag]
+RUN pip3 uninstall flash-attn -y
+RUN git clone https://github.com/Dao-AILab/flash-attention.git && cd flash-attention && git checkout v2.7.4.post1 && python3 setup.py install
 RUN mkdir .cache && mkdir .cache/torch && export TORCH_HOME=/app/.cache/torch


### PR DESCRIPTION
Solves the 
```
ImportError: /usr/local/lib/python3.10/dist-packages/flash_attn_2_cuda.cpython-310-x86_64-linux-gnu.so: undefined symbol: _ZN3c105ErrorC2ENS_14SourceLocationESs
```
error.