### PR TITLE
ci: normalize Jenkins branch names for push policy

### DIFF
--- a/Jenkinsfile.images
+++ b/Jenkinsfile.images
@@ -53,6 +53,15 @@ pipeline {
           if (!branch) {
             branch = sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
           }
+          if (branch.startsWith('refs/heads/')) {
+            branch = branch.replaceFirst('^refs/heads/', '')
+          }
+          if (branch.startsWith('refs/remotes/origin/')) {
+            branch = branch.replaceFirst('^refs/remotes/origin/', '')
+          }
+          if (branch.startsWith('remotes/origin/')) {
+            branch = branch.replaceFirst('^remotes/origin/', '')
+          }
           if (branch.startsWith('origin/')) {
             branch = branch.replaceFirst('^origin/', '')
           }


### PR DESCRIPTION
## Title
ci: normalize Jenkins branch detection for push policy

## Summary
This PR fixes branch-name detection in the image pipeline so push-policy checks behave correctly across Jenkins branch name formats.

## Problem
The Push Images stage was being skipped in some Jenkins runs even with PUSH_ENABLED=true, because branch values could arrive in formats that were not normalized before policy evaluation.

## Root Cause
Jenkins can expose branch names in multiple forms (for example refs/heads/main or remotes/origin/main).  
The pipeline policy expected normalized names, so branch matching for main/release could fail.

## Changes
1. Added normalization for additional branch formats before push-policy checks.
2. Kept existing push policy unchanged:
   - SHA-tag push allowed only on main or release/* (when PUSH_ENABLED=true)
   - latest push allowed only on main (when PUSH_ENABLED=true)

## Behavior After This PR
1. main is correctly detected across Jenkins branch-name variants.
2. release/* is correctly detected across Jenkins branch-name variants.
3. Feature branches still do not push (by design).

## Validation
1. Verified pipeline logic now normalizes branch strings before computing SHOULD_PUSH and SHOULD_PUSH_LATEST.
2. Confirmed this change is isolated in a dedicated branch and does not modify policy semantics.

## Risk
Low. This is a normalization-only change and does not broaden push permissions.

## Notes
This PR intentionally does not alter tag strategy or branch policy. It only improves branch detection reliability.