### PR TITLE
ci: harden push policy evaluation in Jenkins

### DIFF
--- a/Jenkinsfile.images
+++ b/Jenkinsfile.images
@@ -65,11 +65,13 @@ pipeline {
           if (branch.startsWith('origin/')) {
             branch = branch.replaceFirst('^origin/', '')
           }
+          branch = branch.replaceAll('\\p{C}', '').trim()
 
+          boolean pushEnabled = params.PUSH_ENABLED?.toString()?.toBoolean()
           boolean branchAllowed = (branch == 'main' || branch.startsWith('release/'))
           boolean branchMain = (branch == 'main')
-          env.SHOULD_PUSH = (params.PUSH_ENABLED && branchAllowed) ? 'true' : 'false'
-          env.SHOULD_PUSH_LATEST = (params.PUSH_ENABLED && branchMain) ? 'true' : 'false'
+          env.SHOULD_PUSH = (pushEnabled && branchAllowed) ? 'true' : 'false'
+          env.SHOULD_PUSH_LATEST = (pushEnabled && branchMain) ? 'true' : 'false'
 
           writeFile file: '.ci-image-gpu-base', text: "${env.REGISTRY}/${env.IMAGE_GPU_BASE}:${imageTag}\n"
           writeFile file: '.ci-image-gpu-server', text: "${env.REGISTRY}/${env.IMAGE_GPU_SERVER}:${imageTag}\n"
@@ -78,7 +80,7 @@ pipeline {
           echo "Branch: ${branch}"
           echo "Image tag: ${imageTag}"
           echo "HF credential id: ${params.HF_CREDENTIALS_ID}"
-          echo "Push enabled parameter: ${params.PUSH_ENABLED}"
+          echo "Push enabled parameter: ${pushEnabled}"
           echo "Push policy decision: ${env.SHOULD_PUSH}"
           echo "Latest tag update decision: ${env.SHOULD_PUSH_LATEST}"
         }


### PR DESCRIPTION
## Title
ci: harden Jenkins push-policy evaluation for image pipeline

## Summary
This PR hardens push-policy evaluation in the image pipeline so branch and parameter handling are reliable in Jenkins before deciding whether to run `Push Images`.

## Problem
Push decisions were difficult to trust across Jenkins runs because branch and boolean evaluation can vary by environment and checkout style. We need deterministic policy evaluation before merging and running publish from `main`.

## What Changed
1. Normalize branch input before policy checks.
2. Sanitize branch string to remove hidden control characters.
3. Coerce `PUSH_ENABLED` explicitly to a boolean before evaluating push flags.
4. Keep existing policy semantics unchanged:
   - Push SHA tags only when branch is `main` or `release/*`
   - Push `latest` only when branch is `main`

## Why This Is Safe
1. No broadening of publish permissions.
2. No change to image names, tagging format, or registry target.
3. Only improves correctness and predictability of gate evaluation.

## Validation
1. Pipeline run on branch `fix/jenkins-push-policy-eval` shows:
   - `Branch: fix/jenkins-push-policy-eval`
   - `Push enabled parameter: true`
   - `Push policy decision: false`
   - `Latest tag update decision: false`
2. This is expected and confirms policy is enforced correctly on non-eligible branches.

## Post-Merge Plan
1. Merge this PR to `main`.
2. Re-run Jenkins image pipeline from `main` with:
   - `NO_CACHE: true`
   - `PUSH_ENABLED: true`
   - `RUN_INTEGRATION: true`
   - `HF_CREDENTIALS_ID: hf`
   - `SMOKE_MODE: api`
   - `SMOKE_TIMEOUT_SEC: 120`
   - `INTEGRATION_PYTEST_ARGS: -q`
   - `INTEGRATION_TEST_FILES: /app/tests/test_pipeline_python_api_integration.py /app/tests/test_pipeline_tantivy_integration.py`
3. Confirm:
   - `Push policy decision: true`
   - `Latest tag update decision: true`
   - `Push Images` stage runs and publishes SHA + `latest` tags.