### PR TITLE
fix: handle nvidia-smi 'CUDA UMD Version' label and cap PyTorch CUDA index

### DIFF
--- a/create_venv_colette.sh
+++ b/create_venv_colette.sh
@@ -9,7 +9,7 @@ if command -v nvcc &> /dev/null; then
     cuda_short=$(echo $cuda_version | sed 's/\.//')
     echo "cu${cuda_short}"
 elif command -v nvidia-smi &> /dev/null; then
-    cuda_version=$(nvidia-smi | grep "CUDA Version" | sed 's/.*CUDA Version: \([0-9]*\.[0-9]*\).*/\1/')
+    cuda_version=$(nvidia-smi | grep -i "CUDA.*Version" | sed 's/.*CUDA[^:]*Version: \([0-9]*\.[0-9]*\).*/\1/')
     cuda_short=$(echo $cuda_version | sed 's/\.//')
     echo "CUDA found: cu${cuda_short}"
 else

--- a/scripts/install_python_deps.sh
+++ b/scripts/install_python_deps.sh
@@ -27,7 +27,7 @@ if [ -z "${COLETTE_CUDA_SHORT}" ]; then
         cuda_version=$(nvcc --version | sed -n 's/.*release \([0-9]*\.[0-9]*\).*/\1/p' | head -n1)
         COLETTE_CUDA_SHORT="${cuda_version/.}"
     elif command -v nvidia-smi >/dev/null 2>&1; then
-        cuda_version=$(nvidia-smi | sed -n 's/.*CUDA Version: \([0-9]*\.[0-9]*\).*/\1/p' | head -n1)
+        cuda_version=$(nvidia-smi | sed -n 's/.*CUDA[^:]*Version: \([0-9]*\.[0-9]*\).*/\1/p' | head -n1)
         COLETTE_CUDA_SHORT="${cuda_version/.}"
     else
         echo "ERROR: COLETTE_CUDA_SHORT is not set and CUDA version could not be auto-detected." >&2
@@ -38,6 +38,14 @@ fi
 if ! [[ "${COLETTE_CUDA_SHORT}" =~ ^[0-9]+$ ]]; then
     echo "ERROR: invalid COLETTE_CUDA_SHORT='${COLETTE_CUDA_SHORT}'" >&2
     exit 1
+fi
+
+# PyTorch wheels are published for specific CUDA versions; cap to the highest one
+# that ships torch ${TORCH_VERSION} so newer drivers still get a valid index URL.
+PYTORCH_MAX_CUDA_SHORT="${PYTORCH_MAX_CUDA_SHORT:-128}"
+if [ "${COLETTE_CUDA_SHORT}" -gt "${PYTORCH_MAX_CUDA_SHORT}" ]; then
+    echo "WARNING: CUDA cu${COLETTE_CUDA_SHORT} has no PyTorch ${TORCH_VERSION} wheel; falling back to cu${PYTORCH_MAX_CUDA_SHORT} (driver is forward-compatible)." >&2
+    COLETTE_CUDA_SHORT="${PYTORCH_MAX_CUDA_SHORT}"
 fi
 
 TORCH_INDEX_URL="https://download.pytorch.org/whl/cu${COLETTE_CUDA_SHORT}"


### PR DESCRIPTION
## Summary

- Newer NVIDIA drivers (610+) changed the `nvidia-smi` label from `CUDA Version: X.Y` to `CUDA UMD Version: X.Y`, causing the grep/sed pattern in `create_venv_colette.sh` and `scripts/install_python_deps.sh` to return an empty string and fail `COLETTE_CUDA_SHORT` validation with `exit 1`.
- Adds a `PYTORCH_MAX_CUDA_SHORT` cap (default: `128`) so that when the detected CUDA version is newer than any published PyTorch wheel (e.g. `cu133`), the installer falls back to the highest compatible wheel instead of failing with "no matching distribution found".

## Changes

- `create_venv_colette.sh`: broaden grep/sed pattern from `CUDA Version:` to `CUDA[^:]*Version:` to match both old and new label formats.
- `scripts/install_python_deps.sh`: same pattern fix for auto-detection; adds a post-detection cap that warns and falls back to `cu${PYTORCH_MAX_CUDA_SHORT}` when the driver CUDA version exceeds what PyTorch publishes wheels for.

## Test plan

- [ ] Run `./create_venv_colette.sh` on a machine with NVIDIA driver 610+ (CUDA UMD Version label) — should detect CUDA and proceed.
- [ ] Confirm warning is printed and `cu128` index is used when CUDA version > 128.
- [ ] Existing behavior is unchanged for machines where `nvcc` is available or where `nvidia-smi` reports the classic `CUDA Version:` label.