### PR TITLE
feat: add opt-in TwelveLabs (Marengo/Pegasus) embedding_lib for video-aware RAG

### DIFF
--- a/docs/source/users/configuration.md
+++ b/docs/source/users/configuration.md
@@ -148,8 +148,18 @@ This section controls how Colette **filters and processes files** before they ar
 Controls settings for **retrieval and vector database indexing**:
 - **`indexdb_lib`**: The vector database used (`chromadb`).
 - **`retrieval_mode`**: Retrieval strategy (`embedding_retrieval`, `text_search_retrieval`, `hybrid`).
-- **`embedding_lib`**: The library used to compute text embeddings (`huggingface`).
+- **`embedding_lib`**: The library used to compute text embeddings (`huggingface`, `colbert`, `vllm`, or `twelvelabs`).
 - **`embedding_model`**: The embedding model (`intfloat/multilingual-e5-small`).
+
+> **TwelveLabs (optional, video-aware multimodal RAG).** Set `"embedding_lib": "twelvelabs"`
+> to embed text with the TwelveLabs [Marengo](https://twelvelabs.io) model (512-dim multimodal
+> vectors shared across text/image/audio/video). `embedding_model` is optional and defaults to
+> `marengo3.0`. Requires `pip install twelvelabs` and the `TWELVELABS_API_KEY` environment
+> variable (free tier available at https://twelvelabs.io). Because Marengo embeds text and video
+> into the same space, you can also turn videos into searchable text with the Pegasus helper
+> `colette.backends.langchain.rag.twelvelabs_embeddings.analyze_video(prompt=..., url=...)` and
+> index the result like any other document. This integration is fully opt-in and does not change
+> any existing defaults.
 - **`gpu_id`**: Specifies which GPU to use (`0` means the first available GPU).
 - **`text_search_engine_top_k`**: Number of text-search hits to fetch.
 - **`text_search_engine_fields`**: Indexed fields queried by the text search engine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ trag = [
     "llama-cpp-python==0.3.1",
     "pymupdf==1.26.4",
     "tantivy==0.25.1",
+    "twelvelabs>=1.2.8",
 ]
 
 [project.scripts]

--- a/src/colette/apidata.py
+++ b/src/colette/apidata.py
@@ -65,8 +65,9 @@ class RAGObj(BaseModel):
     """ Indexing database library, chromadb or coldb """
     retrieval_mode: Literal["embedding_retrieval", "text_search_retrieval", "hybrid"] = "embedding_retrieval"
     """ Retrieval mode: embedding-only, text-search-only, or hybrid in parallel """
-    embedding_lib: Literal["huggingface", "colbert", "vllm"] = "huggingface"
-    """ Embedding library, use colbert with coldb, huggingface for V-RAG """
+    embedding_lib: Literal["huggingface", "colbert", "vllm", "twelvelabs"] = "huggingface"
+    """ Embedding library, use colbert with coldb, huggingface for V-RAG,
+    twelvelabs for Marengo multimodal (text/video) embeddings via the TwelveLabs API """
     embedding_model: str | None = None
     """ Embedding model, e.g. MrLight/dse-qwen2-2b-mrl-v1 """
     embedding_model_path: str | None = None

--- a/src/colette/backends/langchain/rag/rag_txt.py
+++ b/src/colette/backends/langchain/rag/rag_txt.py
@@ -102,7 +102,12 @@ class RAGTxt:
 
             self.text_search_engine_index = TantivyIndex(self.app_repository / "index" / "text_search_engine", self.logger)
 
-            if retrieval_mode_uses_embedding_retrieval(ad.rag.retrieval_mode) and ad.rag.embedding_model is None:
+            # twelvelabs (Marengo) has a sensible default model, so embedding_model is optional there
+            if (
+                retrieval_mode_uses_embedding_retrieval(ad.rag.retrieval_mode)
+                and ad.rag.embedding_model is None
+                and ad.rag.embedding_lib != "twelvelabs"
+            ):
                 msg = "Missing rag embedding model"
                 self.logger.error(msg)
                 raise InputConnectorBadParamException(msg)
@@ -129,6 +134,13 @@ class RAGTxt:
                     )
                 elif self.rag_embedding_lib == "colbert":
                     self.rag_embedding = None
+                elif self.rag_embedding_lib == "twelvelabs":
+                    # Marengo multimodal embeddings via the TwelveLabs API (opt-in).
+                    # API-based, so device/cache_folder do not apply; the key is read
+                    # from the TWELVELABS_API_KEY environment variable.
+                    from colette.backends.langchain.rag.twelvelabs_embeddings import MarengoEmbeddings
+
+                    self.rag_embedding = MarengoEmbeddings(model_name=self.rag_embedding_model)
                 else:
                     msg = "Unknown embedding lib " + ad.rag.embedding_lib
                     self.logger.error(msg)

--- a/src/colette/backends/langchain/rag/twelvelabs_embeddings.py
+++ b/src/colette/backends/langchain/rag/twelvelabs_embeddings.py
@@ -1,0 +1,101 @@
+"""TwelveLabs embedding and video-analysis helpers for the text RAG backend.
+
+This is an opt-in integration that lets Colette use TwelveLabs' multimodal
+models inside the existing LangChain/Chroma text-RAG pipeline:
+
+- ``MarengoEmbeddings`` exposes the Marengo model (512-dim multimodal
+  embeddings) through the LangChain ``Embeddings`` interface, so it can be
+  passed wherever ``HuggingFaceEmbeddings`` is used today.
+- ``analyze_video`` calls the Pegasus video-understanding model to turn a
+  video (URL, uploaded asset id, or already-indexed video id) into text that
+  can then be chunked and indexed like any other document.
+
+The API key is read from the ``TWELVELABS_API_KEY`` environment variable and
+is never logged. Grab a free key at https://twelvelabs.io.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Default model names; can be overridden via RAGObj.embedding_model / function args.
+DEFAULT_MARENGO_MODEL = "marengo3.0"
+DEFAULT_PEGASUS_MODEL = "pegasus1.5"
+
+
+def _make_client(api_key: str | None = None):
+    """Build a TwelveLabs client, importing the SDK lazily so it stays optional."""
+    try:
+        from twelvelabs import TwelveLabs
+    except ImportError as exc:  # pragma: no cover - exercised only without the dep
+        msg = "The 'twelvelabs' package is required for the TwelveLabs embedding_lib (pip install twelvelabs)"
+        raise ImportError(msg) from exc
+
+    key = api_key or os.environ.get("TWELVELABS_API_KEY")
+    if not key:
+        msg = "TWELVELABS_API_KEY is not set. Get a free key at https://twelvelabs.io"
+        raise ValueError(msg)
+    return TwelveLabs(api_key=key)
+
+
+class MarengoEmbeddings:
+    """LangChain-compatible embeddings backed by TwelveLabs Marengo.
+
+    Implements the minimal ``Embeddings`` protocol (``embed_documents`` and
+    ``embed_query``) so it is a drop-in replacement for ``HuggingFaceEmbeddings``
+    in the text-RAG Chroma vector store. Marengo returns 512-dim vectors that
+    live in a shared multimodal space (text/image/audio/video), which is what
+    makes it useful for video-aware retrieval.
+    """
+
+    def __init__(self, model_name: str | None = None, api_key: str | None = None):
+        self.model_name = model_name or DEFAULT_MARENGO_MODEL
+        self.client = _make_client(api_key)
+
+    def _embed(self, text: str) -> list[float]:
+        resp = self.client.embed.create(model_name=self.model_name, text=text)
+        segments = resp.text_embedding.segments
+        if not segments or segments[0].float_ is None:
+            msg = "TwelveLabs Marengo returned no text embedding"
+            raise RuntimeError(msg)
+        return list(segments[0].float_)
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self._embed(t) for t in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._embed(text)
+
+
+def analyze_video(
+    *,
+    prompt: str,
+    url: str | None = None,
+    asset_id: str | None = None,
+    video_id: str | None = None,
+    model_name: str | None = None,
+    max_tokens: int = 2048,
+    api_key: str | None = None,
+) -> str:
+    """Run TwelveLabs Pegasus video understanding and return the generated text.
+
+    Provide exactly one source: a public ``url``, an uploaded ``asset_id``, or
+    an already-indexed ``video_id``. The returned text can be fed into the
+    normal text-RAG chunking/indexing path so video content becomes searchable
+    alongside documents.
+    """
+    sources = [s for s in (url, asset_id, video_id) if s]
+    if len(sources) != 1:
+        msg = "analyze_video requires exactly one of: url, asset_id, video_id"
+        raise ValueError(msg)
+
+    client = _make_client(api_key)
+    kwargs = {"model_name": model_name or DEFAULT_PEGASUS_MODEL, "prompt": prompt, "max_tokens": max_tokens}
+    if video_id:
+        kwargs["video_id"] = video_id
+    else:
+        from twelvelabs.types.video_context import VideoContext_AssetId, VideoContext_Url
+
+        kwargs["video"] = VideoContext_Url(url=url) if url else VideoContext_AssetId(asset_id=asset_id)
+
+    return client.analyze(**kwargs).data

--- a/tests/test_twelvelabs_embeddings.py
+++ b/tests/test_twelvelabs_embeddings.py
@@ -1,0 +1,62 @@
+import os
+
+import pytest
+
+from colette.backends.langchain.rag.twelvelabs_embeddings import (
+    DEFAULT_MARENGO_MODEL,
+    MarengoEmbeddings,
+    analyze_video,
+)
+
+
+@pytest.mark.smoke
+def test_marengo_embeddings_monkeypatch(monkeypatch):
+    """No-network unit test: the LangChain Embeddings protocol is wired correctly."""
+
+    class DummySegment:
+        float_ = [0.1] * 512
+
+    class DummyTextEmbedding:
+        segments = [DummySegment()]
+
+    class DummyResp:
+        text_embedding = DummyTextEmbedding()
+
+    class DummyEmbed:
+        def create(self, *, model_name, text):
+            assert model_name == DEFAULT_MARENGO_MODEL
+            assert isinstance(text, str)
+            return DummyResp()
+
+    class DummyClient:
+        embed = DummyEmbed()
+
+    monkeypatch.setattr(
+        "colette.backends.langchain.rag.twelvelabs_embeddings._make_client",
+        lambda api_key=None: DummyClient(),
+    )
+
+    emb = MarengoEmbeddings()
+    assert emb.embed_query("a cat playing piano") == [0.1] * 512
+    docs = emb.embed_documents(["one", "two"])
+    assert len(docs) == 2 and len(docs[0]) == 512
+
+
+def test_analyze_video_requires_single_source():
+    with pytest.raises(ValueError):
+        analyze_video(prompt="summarize", url="http://x", video_id="abc")
+    with pytest.raises(ValueError):
+        analyze_video(prompt="summarize")
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("TWELVELABS_API_KEY"),
+    reason="requires TWELVELABS_API_KEY (free key at https://twelvelabs.io)",
+)
+def test_marengo_live_embedding_dim():
+    """Live smoke: Marengo returns a 512-dim text embedding."""
+    emb = MarengoEmbeddings()
+    vec = emb.embed_query("a red sports car on a coastal highway")
+    assert len(vec) == 512
+    assert all(isinstance(x, float) for x in vec[:8])


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR extends Colette's multimodal RAG with **video** by adding an opt-in `twelvelabs` embedding library to the langchain text-RAG backend.

### What it adds
- **`MarengoEmbeddings`** (`src/colette/backends/langchain/rag/twelvelabs_embeddings.py`): TwelveLabs' Marengo model exposed through the LangChain `Embeddings` interface (512-dim multimodal vectors shared across text/image/audio/video). It's a drop-in alternative to `HuggingFaceEmbeddings` in the existing Chroma vector store.
- **`embedding_lib: "twelvelabs"`** wired into `RAGObj` (`apidata.py`) and the `RAGTxt.init` dispatch, alongside the existing `huggingface`/`colbert`/`vllm` options. `embedding_model` is optional and defaults to `marengo3.0`.
- **`analyze_video()`** Pegasus helper: turns a video (public URL, uploaded asset id, or indexed video id) into text you can chunk and index like any other document — so video content becomes searchable next to your PDFs. Because Marengo embeds text and video into the same space, retrieval stays coherent.

### Why it helps Colette
Colette is already a multimodal/V-RAG system; this lets users bring **video** into the same RAG pipeline without leaving the existing config/registry conventions, using a hosted API (no extra GPU/VRAM needed for the embedder).

### Opt-in / non-breaking
Defaults are unchanged. The `twelvelabs` SDK is imported lazily (only when selected), and the API key is read from `TWELVELABS_API_KEY` and never logged. Existing `huggingface`/`colbert`/`vllm` paths are untouched.

### How it was tested
- `ruff format` + `ruff check` clean on the new files (pre-existing repo lint untouched).
- A no-network unit test (`@pytest.mark.smoke`) verifying the LangChain `Embeddings` wiring with a mocked client, plus argument validation for `analyze_video`.
- A `TWELVELABS_API_KEY`-gated live integration test (follows the repo's `COLETTE_RUN_INTEGRATION=1` convention) that confirms Marengo returns a real **512-dim** text embedding. I ran it against the live API and it passes.

The dependency is added to the `trag` (text-RAG) optional extra in `pyproject.toml`, and `docs/source/users/configuration.md` documents the new option.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.