### PR TITLE
fix: Qwen3-VL thinking blocks, gme embedding quality, Tantivy query safety, and kvstore stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ models/
 
 # examples folder
 examples/*.png
+examples/questions_gaia_converter_demo.ipynb
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -70,3 +71,4 @@ tests/pipeline_debug_qwen2vl.log
 docs/gaia_converter/
 docs/gaia_converter_flat/
 app_colette_demo_gaia_converter/
+app_colette_demo_gaia_converter_v0/

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ tests/pipeline_debug_qwen2vl.log
 
 # CI artifacts
 .ci-artifacts/
+
+# Gaia-converter demo stuff/
+docs/gaia_converter/
+docs/gaia_converter_flat/
+app_colette_demo_gaia_converter/

--- a/README.md
+++ b/README.md
@@ -179,16 +179,19 @@ import os
 colette_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 print(f'Colette root path: {colette_root}')
 
-colette_api = JSONApi()
-
 documents_dir = os.path.join(colette_root, 'docs/pdf') # where the input documents are located
 app_dir = os.path.join(colette_root, 'app_colette') # where to store the app
 models_dir = os.path.join(colette_root, 'models') # where the models are located
+
+# If the app already has a saved config (query-only run), use it.
+# On a fresh install fall back to the default template.
+_app_config = os.path.join(app_dir, 'config.json')
+config_file = _app_config if os.path.exists(_app_config) else os.path.join(colette_root, 'src/colette/config/vrag_default.json')
+index_file = os.path.join(colette_root, 'src/colette/config/vrag_default_index.json')
+
 app_name = 'app_colette' # name of the app
 
-# read the configuration file
-config_file = os.path.join(colette_root, 'src/colette/config/vrag_default_lite.json')
-index_file = os.path.join(colette_root, 'src/colette/config/vrag_default_index.json')
+colette_api = JSONApi()
 
 with open(config_file, 'r') as f:
     create_config = json.load(f)
@@ -198,17 +201,31 @@ with open(index_file, 'r') as f:
 create_config['app']['repository'] = app_dir
 create_config['app']['models_repository'] = models_dir
 index_config['parameters']['input']['data'] = [documents_dir]
-# Index in hybrid mode so embedding + text-search retrieval are both available.
+
+# Index once in hybrid mode so vector + text-search data are both available.
+# Then per-request retrieval_mode can be 'embedding_retrieval', 'text_search_retrieval', or 'hybrid'
+# without a second service_index call.
 index_config['parameters']['input']['rag']['retrieval_mode'] = 'hybrid'
 #index_config['parameters']['input']['rag']['reindex'] = False # if True, the RAG will be reindexed
+
+
+# Clean up any service from a previous cell run in this session, then (re)create
+try:
+    colette_api.service_delete(app_name)
+except Exception:
+    pass  # no-op if service doesn't exist yet
 
 # Create the service
 api_data_create = APIData(**create_config)
 colette_api.service_create(app_name, api_data_create)
 
-# Index the documents
+# uncomment the following line to index the documents, only if they have not been indexed yet. 
+# It may take a while depending on the number of documents and their size.
 api_data_index = APIData(**index_config)
 colette_api.service_index(app_name, api_data_index)
+
+# Query the service with a question
+question = 'What are the identified sources of errors ?'
 
 # Note the optional 'crop_label' parameter to filter the sources by crop label
 # The default crop labels are: 'text', 'table', 'figure'
@@ -217,7 +234,7 @@ colette_api.service_index(app_name, api_data_index)
 query_api_msg = {
     'parameters': {
         'input': {
-            'message': 'What are the identified sources of errors ?',
+            'message': question
             # 'crop_label': 'text'
         }
     }
@@ -246,24 +263,78 @@ for item in response.sources['context']:
     image.save(image_filename)
     print(f"Image saved as: {image_filename}")
 
-# Optional: override retrieval mode per request
-query_text_search = {
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Retrieval mode examples
+# ─────────────────────────────────────────────────────────────────────────────
+# Colette supports three retrieval modes:
+#   "embedding_retrieval"  - (default) visual embedding retrieval in ChromaDB / ColDB only
+#   "text_search_retrieval" - lexical text search (BM25) only
+#   "hybrid"    - hybrid retrieval (vector + text search)
+#
+# The mode can be set:
+#   A) In the index config so all queries default to it, or
+#   B) Per-request via the predict payload (overrides the service default).
+
+# A) Index mode -----------------------------------------------------------------
+# This script already indexed with retrieval_mode='hybrid' above. That mirrors
+# production usage and avoids a second service_index call.
+
+# B) Per-request override -------------------------------------------------------
+# Even if the service was indexed with mode="embedding_retrieval" you can switch at query time.
+# Only the fields you explicitly set in the request 'rag' block override the
+# service default; everything else inherits from the service config.
+
+# Query using text search only (keyword/BM25 search)
+# Only retrieval_mode is overridden here; text_search_engine_* values are inherited from
+# the service/index JSON defaults unless you explicitly set them.
+
+query_text_search_only = {
     'parameters': {
         'input': {
-            'message': 'What are the identified sources of errors ?',
-            'rag': {'retrieval_mode': 'text_search_retrieval'}
+            'message': question,
+            'rag': {
+                'retrieval_mode': 'text_search_retrieval',
+            }
         }
     }
 }
-response_text_search = colette_api.service_predict(app_name, APIData(**query_text_search))
-for hit in response_text_search.sources.get('text_context', []):
-    print(hit['source'], hit.get('page_number'), hit.get('score'))
 
-# Notes:
-# - If you index with retrieval_mode='hybrid', both embedding and text-search data are available.
-# - The indexing retrieval_mode is persisted in app_colette/config.json.
-# - If chat/predict requests omit parameters.input.rag.retrieval_mode,
-#   Colette falls back to the persisted value from config.json.
+# response_text_search = colette_api.service_predict(app_name, APIData(**query_text_search_only))
+#
+# Note: for retrieval_mode='text_search_retrieval', embedding context is empty and text hits are
+# returned in response_text_search.sources['text_context'].
+#
+# for text_hit in response_text_search.sources.get('text_context', []):
+#     print(f"Source: {text_hit['source']}  page: {text_hit.get('page_number')}")
+#     print(f"Score : {text_hit.get('score', 'n/a')}")
+#     print(text_hit['content'][:200])
+#     print()
+
+# Query using hybrid mode (visual image crops + injected text context)
+
+query_both_modes = {
+    'parameters': {
+        'input': {
+            'message': question,
+            'rag': {
+                'retrieval_mode': 'hybrid',
+            }
+        }
+    }
+}
+
+# response_both = colette_api.service_predict(app_name, APIData(**query_both_modes))
+
+# Inspect text_context sources --------------------------------------------------
+# When retrieval_mode includes "text_search_retrieval", the response sources include a
+# 'text_context' list alongside the image 'context' list.
+#
+# for text_hit in response_both.sources.get('text_context', []):
+#     print(f"Source: {text_hit['source']}  page: {text_hit.get('page_number')}")
+#     print(f"Score : {text_hit.get('score', 'n/a')}")
+#     print(text_hit['content'][:200])
+#     print()
 ```
 
 ### Retrieval modes

--- a/examples/get_start_python_api.ipynb
+++ b/examples/get_start_python_api.ipynb
@@ -407,7 +407,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv_colette",
+   "display_name": "venv_colette (3.12.3)",
    "language": "python",
    "name": "python3"
   },

--- a/examples/get_start_python_api.ipynb
+++ b/examples/get_start_python_api.ipynb
@@ -47,6 +47,7 @@
     "from PIL import Image\n",
     "from IPython.display import display\n",
     "import re\n",
+    "import asyncio\n",
     "\n",
     "import warnings\n",
     "warnings.filterwarnings(\"ignore\", category=DeprecationWarning)\n",
@@ -87,7 +88,10 @@
     "app_dir = os.path.join(colette_root, 'app_colette') # where to store the app\n",
     "models_dir = os.path.join(colette_root, 'models') # where the models are located\n",
     "\n",
-    "config_file = os.path.join(colette_root, 'src/colette/config/vrag_default.json')\n",
+    "# If the app already has a saved config (query-only run), use it.\n",
+    "# On a fresh install fall back to the default template.\n",
+    "_app_config = os.path.join(app_dir, 'config.json')\n",
+    "config_file = _app_config if os.path.exists(_app_config) else os.path.join(colette_root, 'src/colette/config/vrag_default.json')\n",
     "index_file = os.path.join(colette_root, 'src/colette/config/vrag_default_index.json')\n",
     "\n",
     "app_name = 'app_colette' # name of the app"
@@ -127,10 +131,11 @@
     "create_config['app']['repository'] = app_dir\n",
     "create_config['app']['models_repository'] = models_dir\n",
     "index_config['parameters']['input']['data'] = [documents_dir]\n",
+    "\n",
     "# Index in hybrid mode so both embedding retrieval and text search retrieval data are available.\n",
     "# All retrieval_mode values ('embedding_retrieval', 'text_search_retrieval', 'hybrid') then work without re-indexing.\n",
     "index_config['parameters']['input']['rag']['retrieval_mode'] = 'hybrid'\n",
-    "#index_config['parameters']['input']['rag']['reindex'] = False # if True, the RAG will be reindexed\n"
+    "#index_config['parameters']['input']['rag']['reindex'] = False # if True, the RAG will be reindexed"
    ]
   },
   {
@@ -139,6 +144,20 @@
    "metadata": {},
    "source": [
     "## Create the Service API client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c12b1e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up any service from a previous cell run in this session, then (re)create\n",
+    "try:\n",
+    "    await colette_api.service_delete(app_name)\n",
+    "except Exception:\n",
+    "    pass  # no-op if service doesn't exist yet"
    ]
   },
   {
@@ -167,7 +186,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# index the documents\n",
+    "# uncomment the following line to index the documents, only if they have not been indexed yet. \n",
+    "# It may take a while depending on the number of documents and their size.\n",
     "api_data_index = APIData(**index_config)\n",
     "colette_api.service_index(app_name, api_data_index)"
    ]
@@ -193,6 +213,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c744f47f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query the service with a question\n",
+    "question = 'What are the identified sources of errors ?'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "d60dc68c",
    "metadata": {},
    "outputs": [],
@@ -201,8 +232,9 @@
     "query_api_msg = {\n",
     "    'parameters': {\n",
     "        'input': {\n",
-    "            'message': 'What are the identified sources of errors ?',\n",
+    "            'message': question,\n",
     "            # 'crop_label': 'text',  # optional, to specify a crop label\n",
+    "            # 'top_k': 8,  # retrieve more candidates; default 4 may miss the right page\n",
     "        }\n",
     "    }\n",
     "}\n",
@@ -307,7 +339,7 @@
     "query_text_search = {\n",
     "    'parameters': {\n",
     "        'input': {\n",
-    "            'message': 'What are the identified sources of errors ?',\n",
+    "            'message': question,\n",
     "            'rag': {\n",
     "                'retrieval_mode': 'text_search_retrieval',\n",
     "            }\n",
@@ -402,6 +434,17 @@
     "    image = display_image_from_data_uri(item['content'])\n",
     "    print(f\"Image size: {image.size}\")\n",
     "    print(\"-\" * 50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdb90908",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run this before restarting the kernel to safely flush and close kvstore.db\n",
+    "await colette_api.service_delete(app_name)"
    ]
   }
  ],

--- a/examples/get_start_python_api.py
+++ b/examples/get_start_python_api.py
@@ -15,16 +15,19 @@ import os
 colette_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 print(f'Colette root path: {colette_root}')
 
-colette_api = JSONApi()
-
 documents_dir = os.path.join(colette_root, 'docs/pdf') # where the input documents are located
 app_dir = os.path.join(colette_root, 'app_colette') # where to store the app
 models_dir = os.path.join(colette_root, 'models') # where the models are located
+
+# If the app already has a saved config (query-only run), use it.
+# On a fresh install fall back to the default template.
+_app_config = os.path.join(app_dir, 'config.json')
+config_file = _app_config if os.path.exists(_app_config) else os.path.join(colette_root, 'src/colette/config/vrag_default.json')
+index_file = os.path.join(colette_root, 'src/colette/config/vrag_default_index.json')
+
 app_name = 'app_colette' # name of the app
 
-# read the configuration file
-config_file = os.path.join(colette_root, 'src/colette/config/vrag_default.json')
-index_file = os.path.join(colette_root, 'src/colette/config/vrag_default_index.json')
+colette_api = JSONApi()
 
 with open(config_file, 'r') as f:
     create_config = json.load(f)
@@ -34,19 +37,31 @@ with open(index_file, 'r') as f:
 create_config['app']['repository'] = app_dir
 create_config['app']['models_repository'] = models_dir
 index_config['parameters']['input']['data'] = [documents_dir]
+
 # Index once in hybrid mode so vector + text-search data are both available.
 # Then per-request retrieval_mode can be 'embedding_retrieval', 'text_search_retrieval', or 'hybrid'
 # without a second service_index call.
 index_config['parameters']['input']['rag']['retrieval_mode'] = 'hybrid'
 #index_config['parameters']['input']['rag']['reindex'] = False # if True, the RAG will be reindexed
 
+
+# Clean up any service from a previous cell run in this session, then (re)create
+try:
+    colette_api.service_delete(app_name)
+except Exception:
+    pass  # no-op if service doesn't exist yet
+
 # Create the service
 api_data_create = APIData(**create_config)
 colette_api.service_create(app_name, api_data_create)
 
-# Index the documents
+# uncomment the following line to index the documents, only if they have not been indexed yet. 
+# It may take a while depending on the number of documents and their size.
 api_data_index = APIData(**index_config)
 colette_api.service_index(app_name, api_data_index)
+
+# Query the service with a question
+question = 'What are the identified sources of errors ?'
 
 # Note the optional 'crop_label' parameter to filter the sources by crop label
 # The default crop labels are: 'text', 'table', 'figure'
@@ -55,7 +70,7 @@ colette_api.service_index(app_name, api_data_index)
 query_api_msg = {
     'parameters': {
         'input': {
-            'message': 'What are the identified sources of errors ?'
+            'message': question
             # 'crop_label': 'text'
         }
     }
@@ -109,16 +124,18 @@ for item in response.sources['context']:
 # Query using text search only (keyword/BM25 search)
 # Only retrieval_mode is overridden here; text_search_engine_* values are inherited from
 # the service/index JSON defaults unless you explicitly set them.
+
 query_text_search_only = {
     'parameters': {
         'input': {
-            'message': 'What are the identified sources of errors ?',
+            'message': question,
             'rag': {
                 'retrieval_mode': 'text_search_retrieval',
             }
         }
     }
 }
+
 # response_text_search = colette_api.service_predict(app_name, APIData(**query_text_search_only))
 #
 # Note: for retrieval_mode='text_search_retrieval', embedding context is empty and text hits are
@@ -131,16 +148,18 @@ query_text_search_only = {
 #     print()
 
 # Query using hybrid mode (visual image crops + injected text context)
+
 query_both_modes = {
     'parameters': {
         'input': {
-            'message': 'What are the identified sources of errors ?',
+            'message': question,
             'rag': {
                 'retrieval_mode': 'hybrid',
             }
         }
     }
 }
+
 # response_both = colette_api.service_predict(app_name, APIData(**query_both_modes))
 
 # Inspect text_context sources --------------------------------------------------

--- a/src/colette/apidata.py
+++ b/src/colette/apidata.py
@@ -226,7 +226,7 @@ class LLMModelObj(BaseModel):
     """ Whether to load in 8-bit format """
     query_rephrasing: bool = False
     """ Whether to rephrase queries (V-RAG) only """
-    query_rephrasing_num_tok: int = 512
+    query_rephrasing_num_tok: int = 2048
     """ Number of token for rephrasing queries (V-RAG) only """
     external_vllm_server: VLLMServerObj = Field(default_factory=VLLMServerObj)
     """ vllm server parameters """
@@ -238,7 +238,7 @@ class OutputConnectorObj(BaseModel):
     postprocessing: list[str] = Field(default_factory=list)
     output_format: Literal["json"] = "json"
     base64: bool = True
-    num_tokens: int = 512
+    num_tokens: int = 2048
     # XXX: json_schema
 
 

--- a/src/colette/backends/hf/hflib.py
+++ b/src/colette/backends/hf/hflib.py
@@ -154,10 +154,15 @@ class HFLib(LLMLib):
             self.sessions.update_streaming(ad.parameters.input.session_id, response)
 
     def update_index(self, ad: APIData):
+        # kvstore may have been opened read-only (query mode); switch to write mode
+        # for the duration of indexing, then flush and revert to read-only.
+        self.kvstore.reopen("a")
         try:
             nelt = self.inputc.rag_update_index(ad.parameters.input)
         except Exception as e:
             self.logger.error(e, exc_info=True)
             raise InputConnectorInternalException("HFLib input transform error") from e
+        finally:
+            self.kvstore.reopen("r")
         response = APIResponse(message=f"{nelt} elements in rag_index")
         return response

--- a/src/colette/backends/hf/hfmodel.py
+++ b/src/colette/backends/hf/hfmodel.py
@@ -581,10 +581,12 @@ class HFModel(LLMModel):
                         decoded = re.sub(r"<think>.*?</think>", "", decoded, flags=re.DOTALL)
                         if "</think>" in decoded:
                             decoded = decoded.split("</think>", 1)[1]
-                        elif decoded.strip() and not decoded.strip().startswith("<"):
-                            # Thinking filled the entire max_new_tokens budget and was truncated
-                            # before </think> could appear. The whole output is thinking content.
-                            # Increase output.num_tokens so the answer has room to be generated.
+                        elif has_images and decoded.strip() and not decoded.strip().startswith("<"):
+                            # Thinking was enabled (has_images=True) but filled the entire
+                            # max_new_tokens budget before </think> could appear.  The whole
+                            # output is thinking content, not an answer.
+                            # When enable_thinking=False (no images), decoded IS the answer —
+                            # do not discard it.
                             self.logger.warning(
                                 "qwen3-vl: thinking block overflow — no </think> in output. "
                                 "Increase output.num_tokens (currently %d) to leave room for the answer.",

--- a/src/colette/backends/hf/hfmodel.py
+++ b/src/colette/backends/hf/hfmodel.py
@@ -557,11 +557,26 @@ class HFModel(LLMModel):
                             out_ids[len(in_ids) :]
                             for in_ids, out_ids in zip(model_inputs.input_ids, generation, strict=False)
                         ]
+                        # Decode with skip_special_tokens=False so that <think> and </think>
+                        # appear as literal text even though they are registered special tokens.
+                        # This lets the regex below reliably remove the thinking block.
                         decoded = self.processor.batch_decode(
                             generated_ids_trimmed,
-                            skip_special_tokens=True,
+                            skip_special_tokens=False,
                             clean_up_tokenization_spaces=False,
-                        )[0]                        
+                        )[0]
+                        import re
+                        # Qwen3's chat template forces <think> as the last token of the input
+                        # prompt (assistant prefix), so it is trimmed by the len(in_ids) slice.
+                        # Generated output is therefore: [thinking text]</think>\n\n[answer].
+                        # Step 1: regex removes block when both tags appear as literal text.
+                        # Step 2: split on </think> handles the common case (no opening tag).
+                        decoded = re.sub(r"<think>.*?</think>", "", decoded, flags=re.DOTALL)
+                        if "</think>" in decoded:
+                            decoded = decoded.split("</think>", 1)[1]
+                        # Remove remaining control tokens: <|im_end|>, <|endoftext|>, etc.
+                        decoded = re.sub(r"<\|[^|]*\|>", "", decoded)
+                        decoded = decoded.strip()
                     elif self.llm_type == "nanonets":
                         generated_ids_trimmed = [
                             out_ids[len(in_ids) :]

--- a/src/colette/backends/hf/hfmodel.py
+++ b/src/colette/backends/hf/hfmodel.py
@@ -357,7 +357,14 @@ class HFModel(LLMModel):
                 messages = history.copy()
                 messages.append(new_message)
 
-            text = self.processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            chat_template_kwargs = {"tokenize": False, "add_generation_prompt": True}
+            if self.llm_type == "qwen3-vl":
+                # With no images the thinking block exhausts max_new_tokens before </think>
+                # appears, leaving nothing for the actual answer.  Disable thinking for
+                # text-only inputs; keep it on when images are present (helps reasoning).
+                has_images = any(c.get("type") == "image" for c in content)
+                chat_template_kwargs["enable_thinking"] = has_images
+            text = self.processor.apply_chat_template(messages, **chat_template_kwargs)
             image_inputs, video_inputs = process_vision_info(messages)
             model_inputs = self.processor(
                 text=[text],
@@ -574,6 +581,16 @@ class HFModel(LLMModel):
                         decoded = re.sub(r"<think>.*?</think>", "", decoded, flags=re.DOTALL)
                         if "</think>" in decoded:
                             decoded = decoded.split("</think>", 1)[1]
+                        elif decoded.strip() and not decoded.strip().startswith("<"):
+                            # Thinking filled the entire max_new_tokens budget and was truncated
+                            # before </think> could appear. The whole output is thinking content.
+                            # Increase output.num_tokens so the answer has room to be generated.
+                            self.logger.warning(
+                                "qwen3-vl: thinking block overflow — no </think> in output. "
+                                "Increase output.num_tokens (currently %d) to leave room for the answer.",
+                                self.max_new_tokens,
+                            )
+                            decoded = ""
                         # Remove remaining control tokens: <|im_end|>, <|endoftext|>, etc.
                         decoded = re.sub(r"<\|[^|]*\|>", "", decoded)
                         decoded = decoded.strip()

--- a/src/colette/backends/hf/hfmodel.py
+++ b/src/colette/backends/hf/hfmodel.py
@@ -367,7 +367,8 @@ class HFModel(LLMModel):
                 # because there are no images.
                 has_images = any(c.get("type") == "image" for c in content)
                 has_text_context = bool(docs.get("text_context"))
-                chat_template_kwargs["enable_thinking"] = has_images and not has_text_context
+                thinking_enabled = has_images and not has_text_context
+                chat_template_kwargs["enable_thinking"] = thinking_enabled
             text = self.processor.apply_chat_template(messages, **chat_template_kwargs)
             image_inputs, video_inputs = process_vision_info(messages)
             model_inputs = self.processor(
@@ -585,12 +586,11 @@ class HFModel(LLMModel):
                         decoded = re.sub(r"<think>.*?</think>", "", decoded, flags=re.DOTALL)
                         if "</think>" in decoded:
                             decoded = decoded.split("</think>", 1)[1]
-                        elif has_images and decoded.strip() and not decoded.strip().startswith("<"):
-                            # Thinking was enabled (has_images=True) but filled the entire
-                            # max_new_tokens budget before </think> could appear.  The whole
-                            # output is thinking content, not an answer.
-                            # When enable_thinking=False (no images), decoded IS the answer —
-                            # do not discard it.
+                        elif thinking_enabled and decoded.strip() and not decoded.strip().startswith("<"):
+                            # Thinking was enabled but filled the entire max_new_tokens budget
+                            # before </think> could appear.  The whole output is thinking content.
+                            # When thinking is disabled (text-only or hybrid), decoded IS the
+                            # answer — do not discard it.
                             self.logger.warning(
                                 "qwen3-vl: thinking block overflow — no </think> in output. "
                                 "Increase output.num_tokens (currently %d) to leave room for the answer.",

--- a/src/colette/backends/hf/hfmodel.py
+++ b/src/colette/backends/hf/hfmodel.py
@@ -359,11 +359,15 @@ class HFModel(LLMModel):
 
             chat_template_kwargs = {"tokenize": False, "add_generation_prompt": True}
             if self.llm_type == "qwen3-vl":
-                # With no images the thinking block exhausts max_new_tokens before </think>
-                # appears, leaving nothing for the actual answer.  Disable thinking for
-                # text-only inputs; keep it on when images are present (helps reasoning).
+                # Enable thinking only when there are images and NO separate text-search
+                # context snippets (i.e. pure embedding_retrieval).  In hybrid mode the
+                # model analyses both image crops and text passages, producing a thinking
+                # trace that overflows even 4096 tokens before </think> appears and yields
+                # an empty answer.  Text-only (text_search_retrieval) also disables thinking
+                # because there are no images.
                 has_images = any(c.get("type") == "image" for c in content)
-                chat_template_kwargs["enable_thinking"] = has_images
+                has_text_context = bool(docs.get("text_context"))
+                chat_template_kwargs["enable_thinking"] = has_images and not has_text_context
             text = self.processor.apply_chat_template(messages, **chat_template_kwargs)
             image_inputs, video_inputs = process_vision_info(messages)
             model_inputs = self.processor(

--- a/src/colette/backends/hf/hfmodel.py
+++ b/src/colette/backends/hf/hfmodel.py
@@ -588,7 +588,7 @@ class HFModel(LLMModel):
                             self.logger.warning(
                                 "qwen3-vl: thinking block overflow — no </think> in output. "
                                 "Increase output.num_tokens (currently %d) to leave room for the answer.",
-                                self.max_new_tokens,
+                                max_new_tokens,
                             )
                             decoded = ""
                         # Remove remaining control tokens: <|im_end|>, <|endoftext|>, etc.

--- a/src/colette/backends/hf/rag/rag_img.py
+++ b/src/colette/backends/hf/rag/rag_img.py
@@ -461,22 +461,6 @@ class ImageEmbeddingFunction(EmbeddingFunction):
             truncation=True,
             return_tensors="pt",
         ).to("cuda:" + str(self.device))
-        cache_position = torch.arange(0, len(doc_texts)).to("cuda:" + str(self.device))
-        # Some embedding models (e.g., Qwen2 VL) require prepare_inputs_for_generation,
-        # while other embedding models (e.g., Qwen3 embeddings) can be called directly.
-        try:
-            doc_inputs = self.model.prepare_inputs_for_generation(
-                **doc_inputs, cache_position=cache_position, use_cache=False
-            )
-            # prepare_inputs_for_generation may add CPU tensors (e.g. causal mask);
-            # move all tensor values back to the model device.
-            doc_inputs = {
-                k: v.to("cuda:" + str(self.device)) if isinstance(v, torch.Tensor) else v
-                for k, v in doc_inputs.items()
-            }
-        except Exception:
-            # model has no prepare_inputs_for_generation; assume doc_inputs is acceptable
-            pass
 
         # call on the model
         with torch.no_grad():
@@ -491,7 +475,7 @@ class ImageEmbeddingFunction(EmbeddingFunction):
                     # fallback: if `embed` returns tensor-like
                     doc_embeddings = torch.nn.functional.normalize(torch.tensor(outputs), p=2, dim=-1)
             else:
-                output = self.model(**doc_inputs, return_dict=True, output_hidden_states=True)
+                output = self.model(**doc_inputs, use_cache=False, return_dict=True, output_hidden_states=True)
                 # prefer last_hidden_state if available, otherwise use hidden_states
                 if hasattr(output, "last_hidden_state") and output.last_hidden_state is not None:
                     src = output.last_hidden_state

--- a/src/colette/backends/hf/rag/rag_img.py
+++ b/src/colette/backends/hf/rag/rag_img.py
@@ -440,7 +440,7 @@ class ImageEmbeddingFunction(EmbeddingFunction):
                         ],
                     }
                 ]
-        doc_messages.append(message)
+            doc_messages.append(message)
 
         # print("doc_messages=", doc_messages)
 
@@ -543,10 +543,12 @@ class RAGImgRetriever:
         retrieval_mode: str = "embedding_retrieval",
         text_search_engine_top_k: int = 4,
         text_search_engine_fields: list[str] | None = None,
+        top_k: int | None = None,
     ):
         ##- call on DB
         if query_depth_mult is None:
             query_depth_mult = self.query_depth_mult
+        effective_top_k = top_k if top_k is not None else self.top_k
 
         docs = {"ids": [[]], "distances": [[]], "metadatas": [[]]}
         if retrieval_mode_uses_embedding_retrieval(retrieval_mode):
@@ -568,14 +570,14 @@ class RAGImgRetriever:
 
                 docs = self.indexdb.query(
                     query_texts=[question],
-                    n_results=self.top_k * query_depth_mult,
+                    n_results=effective_top_k * query_depth_mult,
                     where=where_filter,
                 )
             else:
                 docs = self.colretriever.invoke(question, query_depth_mult)
 
             self.logger.debug(f"retrieved vector documents: {json.dumps(docs, indent=2)}")
-            docs = self.filter(docs)
+            docs = self.filter(docs, effective_top_k)
 
         if retrieval_mode_uses_text_search_engine(retrieval_mode):
             if self.text_search_engine_index is None:
@@ -591,13 +593,14 @@ class RAGImgRetriever:
 
         return docs
 
-    def filter(self, docs):
+    def filter(self, docs, top_k: int | None = None):
         # filter only top_k docs based on distance
         # we do not filter based on the distance, as it is already done by the embedder
-        if self.remove_duplicates :
-            return sort_and_select_top_k(docs, self.top_k, self.remove_duplicates, self.kvstore, self.logger)
+        k = top_k if top_k is not None else self.top_k
+        if self.remove_duplicates:
+            return sort_and_select_top_k(docs, k, self.remove_duplicates, self.kvstore, self.logger)
         else:
-            return take_top_k(docs, self.top_k)
+            return take_top_k(docs, k)
 
 
 class RAGImg:
@@ -1036,6 +1039,7 @@ class RAGImg:
             retrieval_mode=rag_config.retrieval_mode,
             text_search_engine_top_k=rag_config.text_search_engine_top_k,
             text_search_engine_fields=rag_config.text_search_engine_fields,
+            top_k=rag_config.top_k,
         )
 
         if retrieval_mode_uses_text_search_engine(rag_config.retrieval_mode):

--- a/src/colette/backends/tantivy/tantivy_index.py
+++ b/src/colette/backends/tantivy/tantivy_index.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import re
 import shutil
 from pathlib import Path
 from typing import Any
+
+# Tantivy query-syntax special characters that must be escaped in raw user text.
+_TANTIVY_SPECIAL_RE = re.compile(r'([+\-!(){}\[\]^"~*?:\\/])')
 
 
 def retrieval_mode_uses_embedding_retrieval(retrieval_mode: str) -> bool:
@@ -138,7 +142,13 @@ class TantivyIndex:
         search_fields = fields or ["content", "source"]
         parsed_query = self._build_query_text(query, crop_label)
         searcher = index.searcher()
-        tantivy_query = index.parse_query(parsed_query, search_fields)
+        try:
+            tantivy_query = index.parse_query(parsed_query, search_fields)
+        except ValueError:
+            self.logger.warning(
+                "Tantivy could not parse query (special chars?); falling back to '*'",
+            )
+            tantivy_query = index.parse_query("*", search_fields)
         results = searcher.search(tantivy_query, limit=limit)
 
         # Fallback for low-recall/strict queries: return top documents so text-only
@@ -179,8 +189,12 @@ class TantivyIndex:
         schema_builder.add_text_field("content", stored=True)
         return schema_builder.build()
 
+    def _escape_query(self, query: str) -> str:
+        """Escape Tantivy query-syntax special characters in a raw user string."""
+        return _TANTIVY_SPECIAL_RE.sub(r"\\\1", query)
+
     def _build_query_text(self, query: str, crop_label: str | list[str] | None) -> str:
-        base_query = query.strip() or "content:*"
+        base_query = self._escape_query(query.strip()) or "*"
         filters: list[str] = []
 
         if crop_label is not None:

--- a/src/colette/kvstore.py
+++ b/src/colette/kvstore.py
@@ -91,8 +91,23 @@ class HDF5ImageStorage(ImageStorageInterface):
         for hashed_key in self.hdf5_file.keys():
             yield self.hdf5_file[hashed_key].attrs["key"]
 
+    def reopen(self, mode: Literal["r", "w", "a"]) -> None:
+        """Flush, close, and reopen the HDF5 file in a different mode."""
+        try:
+            if self.hdf5_file.id.valid:
+                self.hdf5_file.flush()
+                self.hdf5_file.close()
+        except Exception:
+            pass
+        self.hdf5_file = h5py.File(self.file_path, mode)
+
     def close(self) -> None:
         """Close the HDF5 file."""
+        try:
+            if self.hdf5_file.id.valid:
+                self.hdf5_file.flush()
+        except Exception:
+            pass
         self.hdf5_file.close()
 
 

--- a/src/colette/llmservice.py
+++ b/src/colette/llmservice.py
@@ -94,7 +94,12 @@ def createLLMService(BaseLLMLib):
                 self.llmmodel.app_repository = self.app_repository
                 self.llmmodel.models_repository = self.models_repository
 
-            self.kvstore = ImageStorageFactory.create_storage("hdf5", self.app_repository / "kvstore.db", "a")
+            kvstore_path = self.app_repository / "kvstore.db"
+            # Open read-only when querying an existing index — a read-only handle
+            # cannot be corrupted by an unclean kernel shutdown.  Indexing (service_index)
+            # calls kvstore.reopen("a") before writing and kvstore.reopen("r") after.
+            kvstore_mode = "r" if (_is_chat and kvstore_path.exists()) else "a"
+            self.kvstore = ImageStorageFactory.create_storage("hdf5", kvstore_path, kvstore_mode)
             params = ad.parameters
             input_params = params.input
             output_params = params.output

--- a/tests/test_tantivy_index.py
+++ b/tests/test_tantivy_index.py
@@ -49,6 +49,33 @@ def test_text_search_engine_index_add_and_search(tmp_path):
     assert hits[0]["source"] == "manual.pdf"
 
 
+def test_search_with_special_char_query_does_not_raise(tmp_path):
+    """Queries containing Tantivy syntax chars (colons, hyphens, parens) must not crash."""
+    index = TantivyIndex(Path(tmp_path) / "text_search_engine", _Logger())
+    index.add_documents(
+        [
+            {
+                "doc_id": "doc-1",
+                "source": "datasheet.pdf",
+                "page_number": 1,
+                "crop_label": "full_page",
+                "content": "EMI Filter FGDS-20A-50V Limiter LGDS300 DC/DC isolated converter 28VDC output.",
+            },
+        ],
+        recreate=True,
+    )
+
+    # French technical query with colons, hyphens, slashes, and parentheses —
+    # the same pattern that caused ValueError in tantivy.parse_query.
+    query = (
+        "EMI Filter : FGDS-20A-50V Limiter : LGDS300 DC/DC isolé : MGMD500 "
+        "La sortie régulée visée est de 28 VDC (PMAX = 320W)"
+    )
+    hits = index.search(query, limit=5, fields=["content"])
+    # Must not raise; results may or may not match depending on tokenisation.
+    assert isinstance(hits, list)
+
+
 def test_build_text_context_applies_budgets():
     hits, context = build_text_context(
         [


### PR DESCRIPTION
## Summary

- **Qwen3-VL thinking blocks leaking into answers** — strip `<think>…</think>` blocks from decoded output for all `qwen3-vl` models; disable thinking entirely for text-only inputs and hybrid mode (both cause overflow at 4096 tokens); fix overflow guard to use `thinking_enabled` flag instead of `has_images` so hybrid mode no longer discards its answer.

- **gme-Qwen2-VL-2B-Instruct embedding quality** — remove `prepare_inputs_for_generation` from `ImageEmbeddingFunction.__call__`. The call passed `cache_position=[0]` (one entry per batch item, not per token), collapsing temporal positional encoding for text queries and pushing cosine distances to ~0.89 instead of the expected ~0.47. Image embeddings were unaffected due to independent 2D spatial RoPE. Fix: pass `use_cache=False` directly in the model forward call. Also fix a batch embedding indentation bug where `doc_messages` was built outside the per-document loop.

- **Tantivy query parser crash on special characters** — user queries containing Tantivy syntax characters (`:` as field selector, `-` as NOT operator, `/`, `(`, `)`, etc.) raised `ValueError` from `parse_query`. Fix: escape all special characters before building the query string; add a `try/except` fallback to `*` as a second safety net.

- **kvstore HDF5 corruption on unclean shutdown** — open kvstore.db read-only during query to prevent partial writes on kernel kill/interrupt.

- **Per-request `top_k` override** — `top_k` in the request parameters now overrides the service-level default at query time.

- **Token budget** — raise default `num_tokens` and `query_rephrasing_num_tok` to 2048.

## Test plan

- [x] `make test-smoke` — 55 tests passed (covers tantivy, embedding loader, embedding integration, retrieval modes, kvstore, jsonapi)
- [x] `make test-integration-pipeline GPU_ID=2` — 3 tests passed, full create→index→predict with both `gme-Qwen2-VL-2B-Instruct` and `Qwen3-VL-Embedding-2B`
- [x] New test `test_search_with_special_char_query_does_not_raise` added to `tests/test_tantivy_index.py` reproducing the French technical query that triggered the Tantivy crash