### PR TITLE
docs: sync documentation with HyDE, BM25 keyword extraction, and example notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,21 @@ https://github.com/user-attachments/assets/7e36b4af-880a-4260-af61-3041b7d60439
 
 ## Key Features
 
-- 📊 Vision Retrieval-Augmented Generation (V-RAG) system by combining the Document Screenshot Embedding/ColPali retrievers for document retrieval with Vision Language Model (VLM).
+- 📊 **Vision RAG (V-RAG)** — treats every document page as an image; preserves tables, figures, diagrams and spatial layout that text extraction loses. Powered by vision embedding models (e.g. `gme-Qwen2-VL`) and VLMs (e.g. `Qwen3-VL`).
 
-- 📚 Text based RAG system by combining unstructured based text extraction, text embedding and common LLMs
+- 🔍 **Hybrid retrieval** — runs vector embedding search and BM25 lexical search (Tantivy) in parallel. Especially effective for technical documents with product codes, part numbers, or rare identifiers.
 
-- 🚀 Multi-Model Support for both embedders and inference VLLMs
+- 💡 **HyDE (Hypothetical Document Embeddings)** — optionally generates a short hypothetical answer passage before retrieval (`llm.use_hyde: true`). The passage is embedded instead of the raw question, landing closer in vector space to real document content.
 
-- 🎨 Image Generation Integration with diffusers
+- 📚 **Text RAG** — classical text-extraction pipeline using `unstructured` + `langchain` for text-only documents.
 
-- 🚀 Effortless Setup, dockerized and our tests show decent results on many corpuses, including technical documentations with images, figure and shemas
+- 🚀 **Multi-backend support** — `huggingface`, `vllm`, `ollama`, `vllm_client` for LLM inference; `chromadb` or `coldb` for vector storage.
+
+- 🎨 **Image generation** integration with diffusers.
+
+- 🧩 **Layout detection** — automatically segments pages into typed crops (`text`, `figure`, `table`, `full_page`) for fine-grained retrieval filtering.
+
+- 🚀 **Effortless setup** — Dockerised; decent out-of-the-box results on technical documentation corpora.
 
 
 ## System Architecture
@@ -158,6 +164,19 @@ colette_cli chat --app-dir app_colette --msg "What are the identified sources of
 The example below is also available in `examples/get_start_python_api.py`.
 There is also a Jupyter notebook version in `examples/get_start_python_api.ipynb`.
 For text-search-only examples, see `examples/text_search_demo.py` and `examples/text_search_demo.ipynb`.
+
+#### Example notebooks
+
+The `examples/` directory contains several Jupyter notebooks for exploring and debugging a colette index:
+
+| Notebook | Description |
+|---|---|
+| `get_start_python_api.ipynb` | End-to-end quickstart: index PDFs, run a RAG query via the Python API |
+| `retrieval_debugger.ipynb` | Step-by-step retrieval debugger: embedding search, HyDE comparison, BM25 inspection, PCA visualisation |
+| `crop_viewer.ipynb` | Browse every indexed image crop by page and crop type |
+| `visualize_embeddings.ipynb` | PCA scatter of the full ChromaDB embedding index |
+
+All notebooks default to `app_colette/` and `docs/pdf/` — run `get_start_python_api.ipynb` first to populate the index.
 
 ##### Index PDFs and query
 
@@ -341,11 +360,25 @@ query_both_modes = {
 
 `parameters.input.rag.retrieval_mode` supports:
 
-- `embedding_retrieval`
-- `text_search_retrieval`
-- `hybrid`
+- `embedding_retrieval` — vector embedding search only (default)
+- `text_search_retrieval` — BM25 keyword search only
+- `hybrid` — both in parallel
 
 See [Text Search Engine](https://colette.chat/doc/users/text_search_engine.html) for details.
+
+### HyDE — Hypothetical Document Embeddings
+
+Enable with `llm.use_hyde: true`. The LLM generates a short hypothetical answer passage before retrieval; that passage is embedded instead of the raw question, improving recall on technical queries where question phrasing differs greatly from document language.
+
+```json
+"llm": {
+    "use_hyde": true,
+    "hyde_num_tokens": 256,
+    "disable_thinking": true
+}
+```
+
+See [Configuration](https://colette.chat/doc/users/configuration.html) for the full option reference.
 
 ## Configurations
 

--- a/docs/source/features.md
+++ b/docs/source/features.md
@@ -1,0 +1,74 @@
+# Features
+
+## Vision RAG (V-RAG)
+
+Colette's primary retrieval mode treats every document page as an image. PDFs are rendered at high DPI, optionally split into layout-detected crops (text blocks, figures, tables, full pages), embedded with a vision-language embedding model (e.g. `gme-Qwen2-VL-2B-Instruct`), and stored in ChromaDB.
+
+At query time the question is embedded and the most similar image crops are retrieved and passed directly to a VLM (e.g. `Qwen3-VL`). This preserves all visual structure — tables, diagrams, formulas, spatial layout — that text extraction would lose.
+
+## Hybrid Retrieval (Embedding + BM25)
+
+Set `retrieval_mode: hybrid` to run vector search and BM25 lexical search in parallel. The embedding channel finds semantically similar crops; the BM25 channel (powered by Tantivy) finds exact keyword matches. Both result sets are injected into the LLM context.
+
+Hybrid mode is especially effective when queries contain product codes, part numbers, or rare identifiers that embedding models cannot reliably distinguish. See [Text Search Engine](text_search_engine.md) for configuration details.
+
+## HyDE — Hypothetical Document Embeddings
+
+When `llm.use_hyde: true`, Colette generates a short *hypothetical answer passage* with the LLM before retrieval, then embeds that passage instead of the raw question. Because the embedding model was trained on document-to-document similarity, a hypothetical passage lands much closer in vector space to real document content than a bare question does — even if the passage is factually imprecise.
+
+The original question is still sent to the LLM unchanged for final answer generation. HyDE adds one LLM call per query; keep `hyde_num_tokens` low (128–256) to minimise latency. See [Configuration](users/configuration.md#hyde--hypothetical-document-embeddings) for usage.
+
+## Layout Detection
+
+When `parameters.input.rag.ragm.layout_detection: true` (default), Colette uses a layout detector to segment each page into typed crops before embedding:
+
+| Crop label | Content |
+|---|---|
+| `text` | Paragraph / body text blocks |
+| `figure` | Charts, photos, diagrams |
+| `table` | Structured tabular data |
+| `full_page` | Whole page fallback |
+
+Querying can be restricted to one or more crop types via the `crop_label` parameter (e.g. `crop_label: "table"` to search only tables).
+
+## Text RAG
+
+In addition to V-RAG, Colette supports a classical text-extraction pipeline using `langchain` + `unstructured`. Documents are chunked, embedded with a text embedding model, and stored in ChromaDB. Useful when documents are text-only and visual fidelity is not required.
+
+## Conversational Mode
+
+Setting `llm.conversational: true` enables session-based multi-turn conversations. Each turn references the same `session_id`; prior turns are summarised and injected as context. See [Conversational RAG](conversational.md) for details.
+
+## Query Rephrasing
+
+When `llm.query_rephrasing: true`, the LLM rewrites the user question into a form more suited to embedding retrieval before the vector search step. This is distinct from HyDE: rephrasing rewrites the question; HyDE generates a hypothetical answer. Both can be combined.
+
+## System Prompt
+
+`llm.system_prompt` injects a custom system message before every user turn. Use it to enforce strict RAG behaviour, set language, or give the model a persona:
+
+```json
+"system_prompt": "Answer only using the provided context. If the answer is not in the context, say so explicitly."
+```
+
+## Multiple Inference Backends
+
+Colette supports several LLM and embedding backends:
+
+| Backend | Use case |
+|---|---|
+| `huggingface` | Local models via Transformers (default for V-RAG) |
+| `vllm` | High-throughput local serving |
+| `ollama` | Lightweight local models |
+| `vllm_client` | Remote vLLM server |
+
+## Example Notebooks
+
+The `examples/` directory contains ready-to-run Jupyter notebooks:
+
+| Notebook | Description |
+|---|---|
+| `get_start_python_api.ipynb` | End-to-end quickstart: index PDFs, run a RAG query |
+| `retrieval_debugger.ipynb` | Step-by-step retrieval debugger: embedding search, HyDE comparison, BM25 inspection, PCA visualisation |
+| `crop_viewer.ipynb` | Browse every indexed image crop by page and label |
+| `visualize_embeddings.ipynb` | PCA scatter of the full ChromaDB index |

--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -1,1 +1,1551 @@
-{"openapi":"3.1.0","info":{"title":"Colette v2 server","description":"*commit:* [ead58e014096805984d58edaa8326eb19b006773]\n\nThis is the Colette v2 API server\n    ","version":"0.1.0"},"paths":{"/v2/info":{"get":{"summary":"Info","operationId":"info_v2_info_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/APIResponse"}}}}}}},"/v2/app/{sname}":{"put":{"summary":"Create Service","operationId":"create_service_v2_app__sname__put","parameters":[{"name":"sname","in":"path","required":true,"schema":{"type":"string","title":"Sname"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/APIData"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/APIResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"post":{"summary":"Create Service","operationId":"create_service_v2_app__sname__put","parameters":[{"name":"sname","in":"path","required":true,"schema":{"type":"string","title":"Sname"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/APIData"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/APIResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"summary":"Delete Service","operationId":"delete_service_v2_app__sname__delete","parameters":[{"name":"sname","in":"path","required":true,"schema":{"type":"string","title":"Sname"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/APIResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/v2/predict/{sname}":{"post":{"summary":"Predict Service","operationId":"predict_service_v2_predict__sname__post","parameters":[{"name":"sname","in":"path","required":true,"schema":{"type":"string","title":"Sname"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/APIData"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/APIResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/v2/index/{sname}":{"post":{"summary":"Index Service","operationId":"index_service_v2_index__sname__post","parameters":[{"name":"sname","in":"path","required":true,"schema":{"type":"string","title":"Sname"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/APIData"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/APIResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}}},"components":{"schemas":{"APIData":{"properties":{"description":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Description"},"app":{"anyOf":[{"$ref":"#/components/schemas/AppObj"},{"type":"null"}]},"parameters":{"$ref":"#/components/schemas/ParametersObj"}},"type":"object","title":"APIData"},"APIResponse":{"properties":{"version":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Version"},"status_code":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Status Code"},"status":{"anyOf":[{"$ref":"#/components/schemas/StatusObj"},{"type":"null"}]},"info":{"anyOf":[{"$ref":"#/components/schemas/InfoObj"},{"type":"null"}]},"service_name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Service Name"},"full_prompt":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Full Prompt"},"full_response":{"anyOf":[{"type":"object"},{"type":"null"}],"title":"Full Response"},"sources":{"anyOf":[{"additionalProperties":{"items":{"type":"object"},"type":"array"},"type":"object"},{"type":"null"}],"title":"Sources"},"message":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Message"},"output":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Output"}},"type":"object","title":"APIResponse"},"AppObj":{"properties":{"repository":{"anyOf":[{"type":"string","format":"directory-path"},{"type":"string","format":"path"}],"title":"Repository"},"create_repository":{"type":"boolean","title":"Create Repository","default":true},"models_repository":{"type":"string","title":"Models Repository"},"init":{"anyOf":[{"type":"string","minLength":1,"format":"uri"},{"type":"null"}],"title":"Init"},"verbose":{"anyOf":[{"$ref":"#/components/schemas/VerboseEnum"},{"type":"null"}],"default":"info"}},"type":"object","title":"AppObj"},"HTTPValidationError":{"properties":{"detail":{"items":{"$ref":"#/components/schemas/ValidationError"},"type":"array","title":"Detail"}},"type":"object","title":"HTTPValidationError"},"IndexObj":{"properties":{"files":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Files","default":["pdf"]},"indexer":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Indexer","default":"colpali"}},"type":"object","title":"IndexObj"},"InfoObj":{"properties":{"services":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Services"}},"type":"object","title":"InfoObj"},"InputConnectorObj":{"properties":{"lib":{"type":"string","title":"Lib","default":"langchain"},"preprocessing":{"anyOf":[{"$ref":"#/components/schemas/PreprocessingObj"},{"type":"null"}]},"rag":{"anyOf":[{"$ref":"#/components/schemas/RAGObj"},{"type":"null"}]},"data_output_type":{"type":"string","title":"Data Output Type","default":"txt"},"template":{"anyOf":[{"$ref":"#/components/schemas/TemplatePromptObj"},{"type":"null"}]},"message":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Message"},"data":{"anyOf":[{"items":{"type":"string","format":"directory-path"},"type":"array"},{"type":"null"}],"title":"Data"},"session_id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Session Id"},"summarize":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Summarize"},"index":{"anyOf":[{"$ref":"#/components/schemas/IndexObj"},{"type":"null"}]},"query_depth_mult":{"type":"integer","title":"Query Depth Mult","default":200}},"type":"object","title":"InputConnectorObj"},"LLMInferenceObj":{"properties":{"lib":{"type":"string","title":"Lib"},"sampling_params":{"type":"object","title":"Sampling Params","default":{"temperature":0}}},"type":"object","title":"LLMInferenceObj"},"LLMModelObj":{"properties":{"source":{"type":"string","title":"Source"},"filename":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Filename"},"shared":{"type":"boolean","title":"Shared","default":false},"inference":{"$ref":"#/components/schemas/LLMInferenceObj"},"context_size":{"type":"integer","title":"Context Size","default":2048},"quantization":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Quantization"},"gpu_ids":{"anyOf":[{"items":{"type":"integer"},"type":"array"},{"type":"null"}],"title":"Gpu Ids"},"memory_utilization":{"type":"number","title":"Memory Utilization","default":0.9},"image_width":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Image Width"},"image_height":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Image Height"},"dtype":{"type":"string","title":"Dtype","default":"auto"},"host":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Host"},"port":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Port"},"conversational":{"type":"boolean","title":"Conversational","default":false},"stitch_crops":{"type":"boolean","title":"Stitch Crops","default":false},"load_in_8bit":{"type":"boolean","title":"Load In 8Bit","default":false}},"type":"object","title":"LLMModelObj"},"OutputConnectorObj":{"properties":{"postprocessing":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Postprocessing"},"output_format":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Output Format","default":"json"}},"type":"object","title":"OutputConnectorObj"},"ParametersObj":{"properties":{"input":{"$ref":"#/components/schemas/InputConnectorObj"},"llm":{"$ref":"#/components/schemas/LLMModelObj"},"output":{"anyOf":[{"$ref":"#/components/schemas/OutputConnectorObj"},{"type":"null"}]}},"type":"object","title":"ParametersObj"},"PreprocessingObj":{"properties":{"files":{"items":{"type":"string"},"type":"array","title":"Files"},"lib":{"type":"string","title":"Lib"},"save_output":{"type":"boolean","title":"Save Output","default":false},"strict":{"type":"boolean","title":"Strict","default":false},"filters":{"items":{"type":"string"},"type":"array","title":"Filters"},"strategy":{"type":"string","title":"Strategy","default":"auto"},"cleaning":{"type":"boolean","title":"Cleaning","default":true},"dpi":{"type":"integer","title":"Dpi","default":300}},"type":"object","title":"PreprocessingObj"},"RAGMultimodalObj":{"properties":{"image_embedding_size":{"type":"integer","title":"Image Embedding Size","default":1536},"layout_detection":{"type":"boolean","title":"Layout Detection","default":true},"layout_detector_gpu_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Layout Detector Gpu Id"},"image_width":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Image Width"},"image_height":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Image Height"},"auto_scale_for_font":{"type":"boolean","title":"Auto Scale For Font","default":false},"min_font_size":{"type":"integer","title":"Min Font Size","default":24},"filter_width":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Filter Width"},"filter_height":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Filter Height"},"index_overview":{"type":"boolean","title":"Index Overview","default":true}},"type":"object","title":"RAGMultimodalObj"},"RAGObj":{"properties":{"indexdb_lib":{"type":"string","title":"Indexdb Lib","default":"chromadb"},"embedding_lib":{"type":"string","enum":["gpt4all","huggingface","colbert"],"title":"Embedding Lib","default":"colbert"},"embedding_model":{"type":"string","title":"Embedding Model"},"embedding_model_path":{"type":"string","title":"Embedding Model Path"},"shared_model":{"type":"boolean","title":"Shared Model","default":false},"chunk_size":{"type":"integer","title":"Chunk Size","default":250},"chunk_overlap":{"type":"integer","title":"Chunk Overlap","default":0},"chunk_num":{"type":"integer","title":"Chunk Num","default":1},"gpu_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Gpu Id","default":-1},"search":{"type":"boolean","title":"Search","default":false},"reindex":{"type":"boolean","title":"Reindex","default":false},"index_protection":{"type":"boolean","title":"Index Protection","default":true},"top_k":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Top K","default":4},"num_partitions":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Num Partitions","default":-1},"index_bsize":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Index Bsize","default":2},"ragm":{"$ref":"#/components/schemas/RAGMultimodalObj","default":{"image_embedding_size":1536,"layout_detection":true,"auto_scale_for_font":false,"min_font_size":24,"index_overview":true}}},"type":"object","title":"RAGObj"},"StatusObj":{"properties":{"code":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Code"},"status":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Status"},"colette_code":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Colette Code"},"colette_message":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Colette Message"}},"type":"object","title":"StatusObj"},"TemplatePromptObj":{"properties":{"template_prompt":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Template Prompt"},"template_prompt_variables":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Template Prompt Variables"}},"type":"object","title":"TemplatePromptObj"},"ValidationError":{"properties":{"loc":{"items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"type":"array","title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error Type"}},"type":"object","required":["loc","msg","type"],"title":"ValidationError"},"VerboseEnum":{"type":"string","enum":["info","debug","warning","error","critical"],"title":"VerboseEnum"}}}}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Colette {VERSION} server",
+    "description": "*commit:* [57ba8099172c6b2a855c6776e6e8801247d80e95]\n\nThis is the Colette v1 API server",
+    "version": "v1"
+  },
+  "paths": {
+    "/v1/info": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "Info",
+        "operationId": "info_v1_info_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/app/{sname}": {
+      "put": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "Create Service",
+        "description": "Create a new service",
+        "operationId": "create_service_v1_app__sname__put",
+        "parameters": [
+          {
+            "name": "sname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Sname"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIData"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "Create Service",
+        "description": "Create a new service",
+        "operationId": "create_service_v1_app__sname__put",
+        "parameters": [
+          {
+            "name": "sname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Sname"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIData"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "Delete Service",
+        "operationId": "delete_service_v1_app__sname__delete",
+        "parameters": [
+          {
+            "name": "sname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Sname"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/predict/{sname}": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "Predict Service",
+        "operationId": "predict_service_v1_predict__sname__post",
+        "parameters": [
+          {
+            "name": "sname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Sname"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIData"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/streaming/{sname}": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "Streaming Service",
+        "operationId": "streaming_service_v1_streaming__sname__post",
+        "parameters": [
+          {
+            "name": "sname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Sname"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIData"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/index/{sname}": {
+      "put": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "Index Service",
+        "operationId": "index_service_v1_index__sname__put",
+        "parameters": [
+          {
+            "name": "sname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Sname"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIData"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/upload/{sname}": {
+      "put": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "Upload Service",
+        "operationId": "upload_service_v1_upload__sname__put",
+        "parameters": [
+          {
+            "name": "sname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Sname"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_service_v1_upload__sname__put"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/index/{sname}/status": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "summary": "Index Status",
+        "operationId": "index_status_v1_index__sname__status_get",
+        "parameters": [
+          {
+            "name": "sname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Sname"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "APIData": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "app": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AppObj"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/ParametersObj"
+          }
+        },
+        "type": "object",
+        "title": "APIData",
+        "description": "Main API object"
+      },
+      "APIResponse": {
+        "properties": {
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
+          },
+          "status_code": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Code"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StatusObj"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "info": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InfoObj"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "service_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Service Name"
+          },
+          "full_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Prompt"
+          },
+          "full_response": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Response"
+          },
+          "sources": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sources"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output"
+          }
+        },
+        "type": "object",
+        "title": "APIResponse",
+        "description": "Main API Response object to all calls"
+      },
+      "AppObj": {
+        "properties": {
+          "repository": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "directory-path"
+              },
+              {
+                "type": "string",
+                "format": "path"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repository"
+          },
+          "create_repository": {
+            "type": "boolean",
+            "title": "Create Repository",
+            "default": true
+          },
+          "models_repository": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Models Repository"
+          },
+          "verbose": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VerboseEnum"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "info"
+          },
+          "log_in_app_dir": {
+            "type": "boolean",
+            "title": "Log In App Dir",
+            "default": true
+          }
+        },
+        "type": "object",
+        "title": "AppObj",
+        "description": "Application information and settings"
+      },
+      "Body_upload_service_v1_upload__sname__put": {
+        "properties": {
+          "ad": {
+            "type": "string",
+            "title": "Ad"
+          },
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Files"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ad"
+        ],
+        "title": "Body_upload_service_v1_upload__sname__put"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "InfoObj": {
+        "properties": {
+          "services": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Services"
+          }
+        },
+        "type": "object",
+        "title": "InfoObj",
+        "description": "System info response object"
+      },
+      "InputConnectorObj": {
+        "properties": {
+          "lib": {
+            "type": "string",
+            "enum": [
+              "coldb",
+              "diffusr",
+              "hf",
+              "langchain"
+            ],
+            "title": "Lib",
+            "default": "hf"
+          },
+          "preprocessing": {
+            "$ref": "#/components/schemas/PreprocessingObj"
+          },
+          "rag": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RAGObj"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "template": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TemplatePromptObj"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "directory-path"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "summarize": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summarize"
+          },
+          "query_depth_mult": {
+            "type": "integer",
+            "title": "Query Depth Mult",
+            "default": 200
+          },
+          "streaming": {
+            "type": "boolean",
+            "title": "Streaming",
+            "default": false
+          },
+          "crop_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crop Label"
+          }
+        },
+        "type": "object",
+        "title": "InputConnectorObj",
+        "description": "Input connector, get data into the proper shape for indexing, searching and answering"
+      },
+      "LLMInferenceObj": {
+        "properties": {
+          "lib": {
+            "type": "string",
+            "enum": [
+              "diffusers",
+              "huggingface",
+              "llamacpp",
+              "ollama",
+              "vllm",
+              "vllm_client"
+            ],
+            "title": "Lib",
+            "default": "huggingface"
+          },
+          "sampling_params": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Sampling Params",
+            "default": {
+              "temperature": 0
+            }
+          }
+        },
+        "type": "object",
+        "title": "LLMInferenceObj",
+        "description": "LLM and multimodal LLM inference parameters"
+      },
+      "LLMModelObj": {
+        "properties": {
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"
+          },
+          "filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filename"
+          },
+          "shared_model": {
+            "type": "boolean",
+            "title": "Shared Model",
+            "default": true
+          },
+          "inference": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LLMInferenceObj"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "context_size": {
+            "type": "integer",
+            "title": "Context Size",
+            "default": 2048
+          },
+          "gpu_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gpu Ids"
+          },
+          "vllm_quantization": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vllm Quantization"
+          },
+          "vllm_memory_utilization": {
+            "type": "number",
+            "title": "Vllm Memory Utilization",
+            "default": 0.9
+          },
+          "vllm_enforce_eager": {
+            "type": "boolean",
+            "title": "Vllm Enforce Eager",
+            "default": true
+          },
+          "image_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Width"
+          },
+          "image_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Height"
+          },
+          "adjust_aspect_ratio": {
+            "type": "boolean",
+            "title": "Adjust Aspect Ratio",
+            "default": true
+          },
+          "dtype": {
+            "type": "string",
+            "title": "Dtype",
+            "default": "auto"
+          },
+          "host": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host"
+          },
+          "port": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Port"
+          },
+          "conversational": {
+            "type": "boolean",
+            "title": "Conversational",
+            "default": false
+          },
+          "stitch_crops": {
+            "type": "boolean",
+            "title": "Stitch Crops",
+            "default": false
+          },
+          "load_in_8bit": {
+            "type": "boolean",
+            "title": "Load In 8Bit",
+            "default": false
+          },
+          "query_rephrasing": {
+            "type": "boolean",
+            "title": "Query Rephrasing",
+            "default": false
+          },
+          "query_rephrasing_num_tok": {
+            "type": "integer",
+            "title": "Query Rephrasing Num Tok",
+            "default": 2048
+          },
+          "external_vllm_server": {
+            "$ref": "#/components/schemas/VLLMServerObj"
+          },
+          "system_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "System Prompt"
+          },
+          "disable_thinking": {
+            "type": "boolean",
+            "title": "Disable Thinking",
+            "default": false
+          },
+          "use_hyde": {
+            "type": "boolean",
+            "title": "Use Hyde",
+            "default": false
+          },
+          "hyde_num_tokens": {
+            "type": "integer",
+            "title": "Hyde Num Tokens",
+            "default": 256
+          }
+        },
+        "type": "object",
+        "title": "LLMModelObj",
+        "description": "Main LLM parameters for answering"
+      },
+      "OutputConnectorObj": {
+        "properties": {
+          "postprocessing": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Postprocessing"
+          },
+          "output_format": {
+            "type": "string",
+            "const": "json",
+            "title": "Output Format",
+            "default": "json"
+          },
+          "base64": {
+            "type": "boolean",
+            "title": "Base64",
+            "default": true
+          },
+          "num_tokens": {
+            "type": "integer",
+            "title": "Num Tokens",
+            "default": 2048
+          }
+        },
+        "type": "object",
+        "title": "OutputConnectorObj",
+        "description": "Output connector for post-processing parameters"
+      },
+      "ParametersObj": {
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/InputConnectorObj"
+          },
+          "llm": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LLMModelObj"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output": {
+            "$ref": "#/components/schemas/OutputConnectorObj"
+          }
+        },
+        "type": "object",
+        "title": "ParametersObj",
+        "description": "Global (input, llm, output) parameters holder"
+      },
+      "PreprocessingObj": {
+        "properties": {
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Files",
+            "default": [
+              "all"
+            ]
+          },
+          "lib": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lib"
+          },
+          "save_output": {
+            "type": "boolean",
+            "title": "Save Output",
+            "default": false
+          },
+          "strict": {
+            "type": "boolean",
+            "title": "Strict",
+            "default": false
+          },
+          "filters": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Filters"
+          },
+          "strategy": {
+            "type": "string",
+            "title": "Strategy",
+            "default": "auto"
+          },
+          "cleaning": {
+            "type": "boolean",
+            "title": "Cleaning",
+            "default": true
+          },
+          "dpi": {
+            "type": "integer",
+            "title": "Dpi",
+            "default": 300
+          }
+        },
+        "type": "object",
+        "title": "PreprocessingObj",
+        "description": "Preprocessing options for indexing calls"
+      },
+      "RAGMultimodalObj": {
+        "properties": {
+          "layout_detection": {
+            "type": "boolean",
+            "title": "Layout Detection",
+            "default": true
+          },
+          "layout_detector_gpu_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Layout Detector Gpu Id"
+          },
+          "layout_detector_model_path": {
+            "type": "string",
+            "title": "Layout Detector Model Path",
+            "default": "https://colette.chat/models/layout/layout_detector_publaynet_merged_6000.pt"
+          },
+          "image_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Width"
+          },
+          "image_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Height"
+          },
+          "auto_scale_for_font": {
+            "type": "boolean",
+            "title": "Auto Scale For Font",
+            "default": false
+          },
+          "min_font_size": {
+            "type": "integer",
+            "title": "Min Font Size",
+            "default": 24
+          },
+          "filter_width": {
+            "type": "integer",
+            "title": "Filter Width",
+            "default": -1
+          },
+          "filter_height": {
+            "type": "integer",
+            "title": "Filter Height",
+            "default": -1
+          },
+          "index_overview": {
+            "type": "boolean",
+            "title": "Index Overview",
+            "default": true
+          }
+        },
+        "type": "object",
+        "title": "RAGMultimodalObj",
+        "description": "Multimodal RAG parameters"
+      },
+      "RAGObj": {
+        "properties": {
+          "indexdb_lib": {
+            "type": "string",
+            "enum": [
+              "chromadb",
+              "coldb"
+            ],
+            "title": "Indexdb Lib",
+            "default": "chromadb"
+          },
+          "retrieval_mode": {
+            "type": "string",
+            "enum": [
+              "embedding_retrieval",
+              "text_search_retrieval",
+              "hybrid"
+            ],
+            "title": "Retrieval Mode",
+            "default": "embedding_retrieval"
+          },
+          "embedding_lib": {
+            "type": "string",
+            "enum": [
+              "huggingface",
+              "colbert",
+              "vllm"
+            ],
+            "title": "Embedding Lib",
+            "default": "huggingface"
+          },
+          "embedding_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Embedding Model"
+          },
+          "embedding_model_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Embedding Model Path"
+          },
+          "shared_model": {
+            "type": "boolean",
+            "title": "Shared Model",
+            "default": true
+          },
+          "chunk_size": {
+            "type": "integer",
+            "title": "Chunk Size",
+            "default": 250
+          },
+          "chunk_overlap": {
+            "type": "integer",
+            "title": "Chunk Overlap",
+            "default": 0
+          },
+          "chunk_num": {
+            "type": "integer",
+            "title": "Chunk Num",
+            "default": 1
+          },
+          "gpu_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gpu Id",
+            "default": -1
+          },
+          "search": {
+            "type": "boolean",
+            "title": "Search",
+            "default": false
+          },
+          "text_search_engine_top_k": {
+            "type": "integer",
+            "title": "Text Search Engine Top K",
+            "default": 4
+          },
+          "text_search_engine_fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Text Search Engine Fields"
+          },
+          "text_search_engine_max_chars_per_doc": {
+            "type": "integer",
+            "title": "Text Search Engine Max Chars Per Doc",
+            "default": 4000
+          },
+          "text_search_engine_max_total_chars": {
+            "type": "integer",
+            "title": "Text Search Engine Max Total Chars",
+            "default": 16000
+          },
+          "reindex": {
+            "type": "boolean",
+            "title": "Reindex",
+            "default": false
+          },
+          "index_protection": {
+            "type": "boolean",
+            "title": "Index Protection",
+            "default": true
+          },
+          "update_index": {
+            "type": "boolean",
+            "title": "Update Index",
+            "default": false
+          },
+          "top_k": {
+            "type": "integer",
+            "title": "Top K",
+            "default": 4
+          },
+          "remove_duplicates": {
+            "type": "boolean",
+            "title": "Remove Duplicates",
+            "default": false
+          },
+          "num_partitions": {
+            "type": "integer",
+            "title": "Num Partitions",
+            "default": -1
+          },
+          "index_bsize": {
+            "type": "integer",
+            "title": "Index Bsize",
+            "default": 2
+          },
+          "ragm": {
+            "$ref": "#/components/schemas/RAGMultimodalObj"
+          },
+          "vllm_rag_quantization": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vllm Rag Quantization"
+          },
+          "vllm_rag_memory_utilization": {
+            "type": "number",
+            "title": "Vllm Rag Memory Utilization",
+            "default": 0.4
+          },
+          "vllm_rag_enforce_eager": {
+            "type": "boolean",
+            "title": "Vllm Rag Enforce Eager",
+            "default": true
+          }
+        },
+        "type": "object",
+        "title": "RAGObj",
+        "description": "Main RAG parameters"
+      },
+      "StatusObj": {
+        "properties": {
+          "code": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "colette_code": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Colette Code"
+          },
+          "colette_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Colette Message"
+          }
+        },
+        "type": "object",
+        "title": "StatusObj",
+        "description": "System status response object"
+      },
+      "TemplatePromptObj": {
+        "properties": {
+          "template_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template Prompt"
+          },
+          "template_prompt_variables": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Template Prompt Variables"
+          }
+        },
+        "type": "object",
+        "title": "TemplatePromptObj",
+        "description": "Template prompt object"
+      },
+      "VLLMServerObj": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url",
+            "default": "http://localhost:8000/v1"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": "token-abc123"
+          }
+        },
+        "type": "object",
+        "title": "VLLMServerObj"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "VerboseEnum": {
+        "type": "string",
+        "enum": [
+          "info",
+          "debug",
+          "warning",
+          "error",
+          "critical"
+        ],
+        "title": "VerboseEnum",
+        "description": "Logging verbosity options"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "info",
+      "description": "Service and version information"
+    },
+    {
+      "name": "app",
+      "description": "Service lifecycle (create, delete)"
+    },
+    {
+      "name": "predict",
+      "description": "Model prediction"
+    },
+    {
+      "name": "streaming",
+      "description": "Streaming model prediction"
+    },
+    {
+      "name": "index",
+      "description": "Indexing documents"
+    }
+  ]
+}

--- a/docs/source/users/configuration.md
+++ b/docs/source/users/configuration.md
@@ -125,8 +125,8 @@ The `parameters` section defines how **data is processed, indexed, and retrieved
         "gpu_id": 0,
         "text_search_engine_top_k": 4,
         "text_search_engine_fields": ["content", "source"],
-        "text_search_engine_max_chars_per_doc": 1500,
-        "text_search_engine_max_total_chars": 6000,
+        "text_search_engine_max_chars_per_doc": 4000,
+        "text_search_engine_max_total_chars": 16000,
         "search": true,
         "reindex": false
     },
@@ -153,8 +153,8 @@ Controls settings for **retrieval and vector database indexing**:
 - **`gpu_id`**: Specifies which GPU to use (`0` means the first available GPU).
 - **`text_search_engine_top_k`**: Number of text-search hits to fetch.
 - **`text_search_engine_fields`**: Indexed fields queried by the text search engine.
-- **`text_search_engine_max_chars_per_doc`**: Max chars per retrieved text hit added to prompt context.
-- **`text_search_engine_max_total_chars`**: Global char cap added to prompt context from text search hits.
+- **`text_search_engine_max_chars_per_doc`**: Max characters kept per retrieved text hit (default: 4000). Increase if pages are being truncated.
+- **`text_search_engine_max_total_chars`**: Total character budget contributed by text search to the LLM context (default: 16000).
 - **`search`**: If `true`, retrieval is enabled.
 - **`reindex`**: If `false`, existing indexes are used instead of re-processing everything.
 
@@ -175,13 +175,47 @@ Defines **where Colette retrieves documents** for processing:
     "source": "llama3.1:latest",
     "inference": {
         "lib": "ollama"
-    }
+    },
+    "system_prompt": null,
+    "disable_thinking": false,
+    "use_hyde": false,
+    "hyde_num_tokens": 256,
+    "query_rephrasing": false,
+    "query_rephrasing_num_tok": 2048
 }
 ```
 This section defines **the language model used for answering queries**:
-- **`source`**: The LLM model version (`llama3.1:latest`).
+- **`source`**: The LLM model version (e.g. `llama3.1:latest`, `Qwen/Qwen3-VL-7B-Instruct`).
 - **`inference`**:
-  - **`lib`**: The inference library (`ollama`).
+  - **`lib`**: The inference library (`ollama`, `huggingface`, `vllm`).
+- **`system_prompt`**: Optional system prompt inserted before the user turn. Useful for enforcing strict RAG behaviour (e.g. `"Answer only using the provided context. If the answer is not in the context, say so."`). Defaults to `null` (model default).
+- **`disable_thinking`**: Set to `true` to force thinking off for Qwen3 models regardless of retrieval mode. Prevents thinking token overflow on long technical queries. Default: `false`.
+- **`use_hyde`**: Enable **HyDE (Hypothetical Document Embeddings)**. When `true`, the LLM generates a short hypothetical answer passage before retrieval; that passage is embedded instead of the raw question, landing closer in vector space to real document content. Default: `false`. See [HyDE](#hyde-hypothetical-document-embeddings) below.
+- **`hyde_num_tokens`**: Token budget for the HyDE passage generation step. Default: `256`.
+- **`query_rephrasing`**: Enable query rephrasing before retrieval (V-RAG only). The LLM rewrites the user question into a form better suited for embedding search. Default: `false`.
+- **`query_rephrasing_num_tok`**: Token budget for query rephrasing. Default: `2048`.
+
+---
+
+### HyDE — Hypothetical Document Embeddings
+
+**Why it helps:** A raw question is linguistically far from how the answer appears in a document. The embedding model was trained on document-to-document similarity, so a *hypothetical answer passage* — even if factually imprecise — lands in a much closer region of the embedding space than the bare question.
+
+**How it works:**
+1. The LLM generates a short passage that *hypothetically* answers the question.
+2. That passage is embedded and used for vector retrieval.
+3. The original question (unchanged) is still sent to the LLM for final answer generation.
+
+**Enable it:**
+```json
+"llm": {
+    "use_hyde": true,
+    "hyde_num_tokens": 256,
+    "disable_thinking": true
+}
+```
+
+> **Note:** HyDE adds one LLM call per query. Set `hyde_num_tokens` to a low value (128–256) to keep latency low. Enabling `disable_thinking` is recommended for Qwen3 models to avoid thinking token overhead during passage generation.
 
 ---
 

--- a/docs/source/users/text_search_engine.md
+++ b/docs/source/users/text_search_engine.md
@@ -1,44 +1,69 @@
 # Text Search Engine
 
-Colette supports lexical retrieval through a text search engine using BM25-style ranking.
+Colette supports lexical retrieval through a text search engine using BM25-style ranking (powered by [Tantivy](https://github.com/quickwit-oss/tantivy)).
 
 ## Retrieval Modes
 
-`parameters.input.rag.retrieval_mode` accepts only:
+`parameters.input.rag.retrieval_mode` accepts:
 
-- `embedding_retrieval`: embedding retrieval only
-- `text_search_retrieval`: text search retrieval only
-- `hybrid`: runs embedding and text search retrieval together
+- `embedding_retrieval`: vector embedding retrieval only (default)
+- `text_search_retrieval`: BM25 text search only
+- `hybrid`: runs embedding and text search in parallel; both result sets are sent to the LLM
+
+## Query Processing
+
+Before a question is sent to the BM25 engine, it goes through **keyword extraction**:
+
+1. Hyphens are replaced by spaces — e.g. `PRODUCT-01-A` becomes `PRODUCT 01 A`, matching the tokens stored during indexing.
+2. English and French stop words are removed (`what`, `is`, `the`, `of`, `quel`, `est`, …).
+3. Single-character tokens are dropped.
+
+This prevents natural-language questions from being sent verbatim to Tantivy, which would escape special characters (turning `PRODUCT-01-A` into `PRODUCT\-01\-A`, an unmatchable token) and degrade BM25 ranking.
+
+**Example:**
+
+| Input question | BM25 query sent |
+|---|---|
+| `What is the output voltage of PRODUCT-01-A?` | `output voltage PRODUCT 01 A` |
+| `Quelles sont les sources d'erreurs identifiées ?` | `sources erreurs identifiées` |
 
 ## Response Sources
 
 Depending on mode, `service_predict(...).sources` contains:
 
-- `sources['context']`: embedding/image context
-- `sources['text_context']`: text-search hits
+- `sources['context']`: embedding/image crops
+- `sources['text_context']`: text-search page hits
 
-Mode behavior:
-
-- `embedding_retrieval` -> `context`
-- `text_search_retrieval` -> `text_context`
-- `hybrid` -> both keys
+| Mode | Keys returned |
+|---|---|
+| `embedding_retrieval` | `context` |
+| `text_search_retrieval` | `text_context` |
+| `hybrid` | both |
 
 ## Configuration Keys
 
-Text-search configuration lives under `parameters.input.rag`:
+All text-search settings live under `parameters.input.rag`:
 
-- `text_search_engine_top_k`
-- `text_search_engine_fields`
-- `text_search_engine_max_chars_per_doc`
-- `text_search_engine_max_total_chars`
+| Key | Default | Description |
+|---|---|---|
+| `text_search_engine_top_k` | `4` | Number of page hits retrieved from the Tantivy index |
+| `text_search_engine_fields` | `["content", "source"]` | Fields queried during full-text search |
+| `text_search_engine_max_chars_per_doc` | `4000` | Max characters kept per retrieved page hit |
+| `text_search_engine_max_total_chars` | `16000` | Total character budget contributed to the LLM context |
+
+> **Tuning tip:** The default 4000 chars/doc covers 100 % of typical datasheet pages. Raising `text_search_engine_max_total_chars` beyond 16000 may improve recall on multi-page answers but increases LLM context usage.
 
 ## Index Paths
 
-Default on-disk paths:
+Default on-disk paths after indexing:
 
-- HF backend: `<app_repository>/mm_index/text_search_engine`
-- LangChain backend: `<app_repository>/index/text_search_engine`
+- HF backend (V-RAG): `<app_repository>/mm_index/text_search_engine/`
+- LangChain backend (text RAG): `<app_repository>/index/text_search_engine/`
+
+The text search index is only created when `retrieval_mode` is `text_search_retrieval` or `hybrid` at index time.
 
 ## Notes
 
 - User-facing naming is engine-agnostic to allow backend replacement without API renaming.
+- The BM25 index stores page-level text extracted during the PDF-to-image pipeline. Each Tantivy document corresponds to one PDF page.
+- To inspect BM25 results interactively, use `examples/retrieval_debugger.ipynb`.


### PR DESCRIPTION
## Summary

Brings all documentation up to date with the three features merged since the last doc update: HyDE retrieval, BM25 keyword extraction fix, and the example notebooks.

## Changes

### `README.md`
- Expanded Key Features list: HyDE, hybrid retrieval, layout detection, multi-backend support — each with a one-line description
- Added Example Notebooks table (`get_start_python_api`, `retrieval_debugger`, `crop_viewer`, `visualize_embeddings`)
- Added HyDE quick-start section with config snippet
- Fixed retrieval mode descriptions (were just enum values, now include a one-line explanation each)

### `docs/source/features.md`
- Was a 0-byte placeholder listed in the Sphinx toctree
- Written from scratch: V-RAG, hybrid retrieval, HyDE, layout detection, text RAG, conversational mode, query rephrasing, system prompt, inference backends, example notebooks

### `docs/source/users/configuration.md`
- Fixed stale BM25 context limits: `text_search_engine_max_chars_per_doc` 1500 → 4000, `text_search_engine_max_total_chars` 6000 → 16000 (matching current defaults in `vrag_default.json`)
- Documented six previously missing `llm` fields:
  - `system_prompt` — custom system message before every user turn
  - `disable_thinking` — force thinking off for Qwen3 models
  - `use_hyde` — enable HyDE retrieval
  - `hyde_num_tokens` — token budget for HyDE passage generation
  - `query_rephrasing` — LLM-based query rewriting before retrieval
  - `query_rephrasing_num_tok` — token budget for rephrasing
- Added a dedicated **HyDE** section explaining the technique, when to use it, and a minimal config example

### `docs/source/users/text_search_engine.md`
- Added **Query Processing** section documenting `_extract_keywords` behaviour: hyphen splitting, stop-word removal, single-char token drop — with a before/after example table
- Updated context limit defaults to 4000/16000
- Added configuration keys table with descriptions and defaults
- Added tuning tip for `text_search_engine_max_total_chars`
- Added note pointing to `retrieval_debugger.ipynb` for interactive BM25 inspection

### `docs/source/openapi.json`
- Regenerated from the current `httpjsonapi.py` FastAPI app
- Previously missing from `LLMModelObj`: `use_hyde`, `hyde_num_tokens`, `disable_thinking`, `system_prompt`, `query_rephrasing`, `query_rephrasing_num_tok`, `shared_model`, `vllm_quantization`, `vllm_memory_utilization`, `vllm_enforce_eager`, `adjust_aspect_ratio`
- Previously missing from `RAGObj`: `retrieval_mode`, all five `text_search_engine_*` fields, `update_index`, `remove_duplicates`, `vllm_rag_*`
- Previously missing from `InputConnectorObj`: `crop_label`, `streaming`

## Test plan

- [ ] Sphinx build passes: `cd docs && make html` — no warnings on `features.md` toctree entry
- [ ] `configuration.md` BM25 defaults match `src/colette/config/vrag_default.json`
- [ ] `openapi.json` fields match `src/colette/apidata.py` `LLMModelObj` and `RAGObj`