### PR TITLE
fix: add PyMuPDF to smoke requirements and fix invalid escape in docstring

### DIFF
--- a/ci/requirements-smoke.txt
+++ b/ci/requirements-smoke.txt
@@ -10,6 +10,7 @@ h5py
 faiss-gpu-cu12==1.12.0
 pypandoc_binary==1.15
 pypdfium2
+PyMuPDF
 transformers==5.3.0
 qwen_vl_utils==0.0.14
 python-doctr==1.0.1

--- a/src/colette/apidata.py
+++ b/src/colette/apidata.py
@@ -24,7 +24,7 @@ class PreprocessingObj(BaseModel):
     strict: bool = False  # do not stop on preprocessing failures
     """ Text-RAG only: whether to fail on preprocessing errors """
     filters: list[str] = Field(default_factory=list)  # list of patterns for filtering data out
-    """ Input preprocessing regex filters, e.g. ["\/~[^\/]*$"] """
+    """ Input preprocessing regex filters, e.g. ["/~[^/]*$"] """
     strategy: str = "auto"
     """ Text-RAG only: text extraction strategy, e.g. auto, fast, hi_res """
     cleaning: bool = True


### PR DESCRIPTION
- ci/requirements-smoke.txt: add PyMuPDF (fitz) required by test_embedding_loader.py and test_embedding_integration.py
- apidata.py: remove invalid escape sequences (\/ → /) in PreprocessingObj.filters docstring — SyntaxWarning in Python 3.12+