### PR TITLE
fix: add langchain-core to smoke CI requirements

### DIFF
--- a/ci/requirements-smoke.txt
+++ b/ci/requirements-smoke.txt
@@ -11,6 +11,7 @@ faiss-gpu-cu12==1.12.0
 pypandoc_binary==1.15
 pypdfium2
 PyMuPDF
+langchain-core
 transformers==5.3.0
 qwen_vl_utils==0.0.14
 python-doctr==1.0.1


### PR DESCRIPTION
## Summary

- `tests/test_retrieval_modes.py` imports `from langchain_core.documents import Document`, but `langchain-core` was missing from `ci/requirements-smoke.txt`
- This caused `ModuleNotFoundError: No module named 'langchain_core'` in the Jenkins smoke test suite
- Same pattern as the previous `PyMuPDF` fix

## Test plan

- [ ] Jenkins smoke suite passes after adding `langchain-core` to `ci/requirements-smoke.txt`
- [ ] No new import errors in `test_retrieval_modes.py`