### PR TITLE
fix: add langchain stack to smoke requirements and mark tests

### DIFF
--- a/ci/requirements-smoke.txt
+++ b/ci/requirements-smoke.txt
@@ -11,7 +11,13 @@ faiss-gpu-cu12==1.12.0
 pypandoc_binary==1.15
 pypdfium2
 PyMuPDF
-langchain-core
+langchain-core==0.3.77
+langchain-community==0.3.30
+langchain-chroma==0.2.6
+langchain-huggingface==0.3.1
+langchain-unstructured==0.1.6
+rank_bm25==0.2.2
+unstructured==0.18.15
 transformers==5.3.0
 qwen_vl_utils==0.0.14
 python-doctr==1.0.1

--- a/tests/test_retrieval_modes.py
+++ b/tests/test_retrieval_modes.py
@@ -1,3 +1,4 @@
+import pytest
 from types import SimpleNamespace
 
 from langchain_core.documents import Document
@@ -46,6 +47,7 @@ class _DummyLogger:
         return None
 
 
+@pytest.mark.smoke
 def test_hf_retriever_vector_mode_uses_only_vector_search():
     indexdb = _DummyIndexDB()
     tantivy = _DummyTantivy()
@@ -70,6 +72,7 @@ def test_hf_retriever_vector_mode_uses_only_vector_search():
     assert "text_context" not in docs
 
 
+@pytest.mark.smoke
 def test_hf_retriever_text_search_mode_uses_only_text_search():
     indexdb = _DummyIndexDB()
     tantivy = _DummyTantivy()
@@ -94,6 +97,7 @@ def test_hf_retriever_text_search_mode_uses_only_text_search():
     assert len(docs["text_context"]) == 1
 
 
+@pytest.mark.smoke
 def test_hf_retriever_both_mode_uses_both_searches():
     indexdb = _DummyIndexDB()
     tantivy = _DummyTantivy()
@@ -118,6 +122,7 @@ def test_hf_retriever_both_mode_uses_both_searches():
     assert len(docs["text_context"]) == 1
 
 
+@pytest.mark.smoke
 def test_rag_txt_retrieve_merges_embedding_and_text_search_documents():
     rag_txt = RAGTxt()
     rag_txt.ad = SimpleNamespace(rag=RAGObj(retrieval_mode="hybrid", text_search_engine_top_k=2))


### PR DESCRIPTION
## Summary

- `test_retrieval_modes.py` was listed in `SMOKE_TESTS` but none of its tests had `@pytest.mark.smoke` — pytest collected the file (triggering imports) but ran zero tests
- Collection imports `rag_txt.py` which requires the full langchain + unstructured stack, causing a cascade of `ModuleNotFoundError` failures in CI
- Fixed both root causes in a single commit:
  1. Added `@pytest.mark.smoke` to all 4 unit tests (they use only dummy objects, no GPU required)
  2. Added `langchain-community`, `langchain-chroma`, `langchain-huggingface`, `langchain-unstructured`, `rank_bm25`, `unstructured` to `ci/requirements-smoke.txt` with versions matching `requirements-full.txt`

## Test plan

- [ ] Jenkins smoke suite collects `test_retrieval_modes.py` without import errors
- [ ] All 4 tests in `test_retrieval_modes.py` appear as selected and pass under `-m smoke`
- [ ] No regression in other smoke test files