### PR TITLE
fix: use shared models repo in test_logging_payload, increase index timeout

### DIFF
--- a/tests/test_logging_payload.py
+++ b/tests/test_logging_payload.py
@@ -7,6 +7,8 @@ from utils import compare_dicts, pretty_print_response, wait_for_index_status
 
 pytestmark = [pytest.mark.integration, pytest.mark.e2e]
 
+models_repo = os.getenv("MODELS_REPO", "models")
+
 
 def generic_index(client, sname, index_json):
     response = client.put(f"/v1/index/{sname}", json=index_json)
@@ -24,7 +26,7 @@ def test_logging_payload(client):
 
         # Step 2: Create a service
         json_create_img_hf = {
-            "app": {"repository": "test_logging_payload_2", "verbose": "debug"},
+            "app": {"repository": "test_logging_payload_2", "models_repository": models_repo, "verbose": "debug"},
             "parameters": {
                 "input": {
                     "lib": "hf",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,7 +66,7 @@ def wait_for_index_status(
     terminal_tokens=("finished",),
     in_progress_tokens=("queued", "running", "started", "indexing"),
     poll_interval_s: float = 0.5,
-    timeout_s: float = 180,
+    timeout_s: float = 600,
 ):
     """Poll index status endpoint until one of the terminal tokens is found."""
     response = client.get(f"/v1/index/{sname}/status")


### PR DESCRIPTION
## Summary

- `test_logging_payload` was using `test_logging_payload_2/models/` as its models directory — a per-test path that gets wiped on teardown. This forced a full re-download of `gme-Qwen2-VL-2B-Instruct` (~8GB) on every CI run, causing two failures:
  1. `wait_for_index_status` timed out at 180s while the embedding model was still downloading
  2. `FileNotFoundError` on `.incomplete` blob files when teardown deleted the directory while `huggingface_hub` was still writing
- Fixed by adding `models_repository = os.getenv("MODELS_REPO", "models")` (same pattern as `test_upload.py`) so the shared cached models dir is used and not deleted by teardown
- Increased `wait_for_index_status` default timeout from 180s → 600s to accommodate first-time model downloads on a cold CI runner

## Test plan

- [ ] `test_logging_payload` reuses cached `gme-Qwen2-VL-2B-Instruct` from the shared `models/` dir instead of re-downloading
- [ ] No `FileNotFoundError` on `.incomplete` blobs in teardown
- [ ] Integration stable suite passes with 5/5 tests