### PR TITLE
fix: ci images pipeline — models dir, smoke imports list, regex warning

### DIFF
--- a/ci/container_integration.sh
+++ b/ci/container_integration.sh
@@ -43,6 +43,8 @@ if [ -z "${GPU_BASE_IMAGE}" ]; then
     exit 1
 fi
 
+mkdir -p "${MODELS_PATH}"
+
 bash "$(dirname "$0")/container_preflight.sh" integration
 
 echo "=== Container integration tests ==="

--- a/ci/verify_smoke_imports.py
+++ b/ci/verify_smoke_imports.py
@@ -27,6 +27,8 @@ SMOKE_TEST_FILES = [
     "tests/test_logger_smoke.py",
     "tests/test_jsonapi_service_smoke.py",
     "tests/test_core_services_smoke.py",
+    "tests/test_apidata_rag_merge.py",
+    "tests/test_retrieval_modes.py",
 ]
 
 

--- a/src/colette/backends/coldb/indexing/loaders.py
+++ b/src/colette/backends/coldb/indexing/loaders.py
@@ -33,7 +33,7 @@ def load_doclens(directory, flatten=True):
     doclens_filenames = {}
 
     for filename in os.listdir(directory):
-        match = re.match("doclens.(\d+).json", filename)
+        match = re.match(r"doclens.(\d+).json", filename)
 
         if match is not None:
             doclens_filenames[int(match.group(1))] = filename


### PR DESCRIPTION
## Summary

Three issues found auditing `Jenkinsfile.images`:

1. **`container_integration.sh`** — `container_preflight.sh integration` hard-fails if `./models` doesn't exist, but `cleanWs` wipes the workspace between builds. Added `mkdir -p "${MODELS_PATH}"` before the preflight call (mirroring what `container_smoke.sh` already does for api mode).

2. **`ci/verify_smoke_imports.py`** — `SMOKE_TEST_FILES` list was missing `test_apidata_rag_merge.py` and `test_retrieval_modes.py`, both of which were added to the Makefile's `SMOKE_TESTS` in earlier PRs. The import preflight in `setup_venv.sh` would have silently skipped those two files.

3. **`coldb/indexing/loaders.py:36`** — `"\d"` → `r"\d"`. Python 3.12 emits `SyntaxWarning: invalid escape sequence` (visible in CI coverage output); a future Python version will raise `SyntaxError`.

## Test plan

- [ ] `Jenkinsfile.images` with `RUN_INTEGRATION=true` passes the preflight even on a fresh workspace (no pre-existing `models/` dir)
- [ ] `verify_smoke_imports.py --workspace .` exits 0 with all 13 smoke test files imported cleanly
- [ ] No `SyntaxWarning` in CI output for `loaders.py`