### PR TITLE
fix: detect indexing error status immediately in wait_for_index_status

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,16 +65,25 @@ def wait_for_index_status(
     sname: str,
     terminal_tokens=("finished",),
     in_progress_tokens=("queued", "running", "started", "indexing"),
+    error_tokens=(": error",),
     poll_interval_s: float = 0.5,
     timeout_s: float = 600,
 ):
-    """Poll index status endpoint until one of the terminal tokens is found."""
+    """Poll index status endpoint until one of the terminal tokens is found.
+
+    Raises immediately if an error token is detected so callers get fast
+    failure rather than burning the full timeout.
+    """
     response = client.get(f"/v1/index/{sname}/status")
     assert response.status_code == 200
 
     deadline = time.time() + timeout_s
     message = (response.json().get("message") or "").lower()
     while not any(token in message for token in terminal_tokens):
+        if any(token in message for token in error_tokens):
+            raise AssertionError(
+                f"Indexing error for '{sname}'. Status: {message}"
+            )
         if not any(token in message for token in in_progress_tokens):
             return response
         if time.time() >= deadline:


### PR DESCRIPTION
## Summary

- The server sets `indexing_status[sname] = "error"` on failure (`jsonapi.py:167`) and the status endpoint returns `"Indexing for {name}: error."`
- `wait_for_index_status` lowercases the message and checks for `"indexing"` in `in_progress_tokens` — the word `"indexing"` appears in the error message, so the function kept polling for the full 600s timeout instead of failing fast
- This caused `test_logging_payload` to run for 17 minutes before reporting the failure, burying the real server-side traceback in the test report
- Added `error_tokens=(": error",)` checked before the in-progress loop — on match, raises `AssertionError` immediately so the actual error surfaces in `Captured stderr` on the next CI run

## Test plan

- [ ] On next Jenkins run, `test_logging_payload` failure reports instantly with `"Indexing error for ..."` rather than burning 10 minutes on timeout
- [ ] Real server-side traceback is visible in `Captured stderr call` section of the test report