### PR TITLE
fix: remove chunk_num=3 from test_logging_payload to fix CUDA OOM

### DIFF
--- a/tests/test_logging_payload.py
+++ b/tests/test_logging_payload.py
@@ -34,8 +34,6 @@ def test_logging_payload(client):
                         "indexdb_lib": "chromadb",
                         "embedding_lib": "huggingface",
                         "embedding_model": "Alibaba-NLP/gme-Qwen2-VL-2B-Instruct",
-                        "chunk_num": 3,
-                        "chunk_overlap": 20,
                         "top_k": 4,
                         "ragm": {"layout_detection": False},
                     },


### PR DESCRIPTION
## Summary

- `test_logging_payload` used `chunk_num: 3` + `layout_detection: False`, generating 4 image parts per document
- With both `Qwen2-VL-2B` and `gme-Qwen2-VL-2B` already in VRAM from the preceding test (`shared_model=True`, 17.83 GiB in use on a 23.55 GiB GPU), the vision-encoder attention softmax for the 4th chunk needed 5.97 GiB but only 5.67 GiB was free → `torch.OutOfMemoryError`
- `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` was already set in `conftest.py` but insufficient when truly out of memory
- Removed `chunk_num` (defaults to `1`) and `chunk_overlap` (text-RAG-only parameter, has no effect in V-RAG). The indexing flow is still fully exercised; `chunk_num > 1` is already marked `[Not recommended]` in the API docs

## Test plan

- [ ] `test_logging_payload` indexes successfully without OOM (1 part per image instead of 4)
- [ ] Integration stable suite passes 5/5