### PR TITLE
fix: cap ragm image resolution to prevent CUDA OOM in test_logging_payload

### DIFF
--- a/tests/test_logging_payload.py
+++ b/tests/test_logging_payload.py
@@ -35,7 +35,11 @@ def test_logging_payload(client):
                         "embedding_lib": "huggingface",
                         "embedding_model": "Alibaba-NLP/gme-Qwen2-VL-2B-Instruct",
                         "top_k": 4,
-                        "ragm": {"layout_detection": False},
+                        "ragm": {
+                            "layout_detection": False,
+                            "image_width": 640,
+                            "image_height": 640,
+                        },
                     },
                     "template": {
                         "template_prompt": "Tu es un assistant de réponse à des questions."


### PR DESCRIPTION
## Summary

- Images in `tests/data_img2` are 1892×2834 pixels. With `layout_detection: False` and no `image_width`/`image_height` set in `ragm`, `rag_img.py` feeds them to the `gme-Qwen2-VL-2B-Instruct` embedding model at native resolution.
- At that resolution, Qwen2-VL generates ~27k visual tokens; the attention softmax alone requires ~5.97 GiB. In CI, prior tests leave both shared models in VRAM (`shared_model=True`), leaving only ~5.69 GiB free → CUDA OOM.
- Fix: add `image_width: 640, image_height: 640` to the `ragm` config in the test. This triggers `thumbnail((640, 640))` in `rag_img.py:354-357`, capping the portrait images to ~427×640 (~1390 tokens, ~15 MB attention).

## Test plan

- [ ] Jenkins integration CI passes `test_logging_payload` without CUDA OOM
- [ ] `compare_dicts` assertion at the end of the test still passes (`config.json` is written via `model_dump()` which includes `image_width`/`image_height` since they are defined on `RAGMultimodalObj`)
- [ ] Local runs unaffected (test was already passing locally due to fresh GPU state)