### PR TITLE
fix: use portrait-friendly image_height for LLM inference in test_logging_payload

### DIFF
--- a/tests/test_logging_payload.py
+++ b/tests/test_logging_payload.py
@@ -52,7 +52,7 @@ def test_logging_payload(client):
                     "source": "Qwen/Qwen2-VL-2B-Instruct",
                     "gpu_ids": [0],
                     "image_width": 640,
-                    "image_height": 320,
+                    "image_height": 960,
                     "inference": {"lib": "huggingface"},
                 },
             },


### PR DESCRIPTION
## Summary

- Documents in `tests/data_img2` are 1892×2834 (portrait, aspect ratio ≈ 0.67).
- The LLM config had `image_height: 320`, giving a target aspect of 640/320 = 2.0 (landscape). `hfmodel.py:318` computed `upper_padding = (946 - 2834) // 2 = -944` — negative — so `PIL.paste` cropped to the middle third of each document instead of padding. The LLM received a garbled fragment and generated only `!` tokens.
- Fix: `image_height: 320 → 960`. Target aspect 640/960 = 0.667 matches the portrait documents, so the adjustment reduces to ~2px of padding and the full page is preserved. Qwen receives `resized_width=640, resized_height=960` (~785 visual tokens vs ~27k at native resolution).
- Verified locally: `test_logging_payload` PASSED in 42s on GPU 0.

## Test plan

- [ ] Jenkins CI: `test_logging_payload` passes the `assert '%' in response.json()["output"]` assertion
- [ ] `compare_dicts` still passes — `LLMModelObj.image_height` is persisted via `model_dump()` into `config.json`
- [ ] No CUDA OOM (ragm embedding capped at 640×640 from previous fix; LLM at 640×960 ≈ 785 tokens)