### PR TITLE
fix: use sdpa attention for all Qwen VL models to prevent flash-attn silent failures

### DIFF
--- a/src/colette/backends/hf/attention.py
+++ b/src/colette/backends/hf/attention.py
@@ -23,12 +23,13 @@ def _contains_token(value: str | None, token: str) -> bool:
 
 
 def resolve_attn_implementation(model_source: str | None = None) -> str:
-    # Qwen3.5 uses 3D mrope position IDs for multimodal tokens. Transformers
-    # 5.x dispatches those through flash-attn's varlen kernel, which crashes
-    # on current hardware (illegal memory access in flash_attn_gpu.varlen_fwd).
-    # PyTorch's native sdpa handles those position IDs correctly and is still
-    # hardware-accelerated — it is NOT the same as eager mode.
-    if _contains_token(model_source, "Qwen3.5") or _contains_token(model_source, "Qwen3_5"):
+    # Qwen VL models use 3D mrope position IDs for multimodal tokens. Transformers
+    # 5.x dispatches those through flash-attn's varlen kernel, which can crash or
+    # silently produce garbage outputs (all-! tokens) depending on GPU/driver
+    # (confirmed on RTX 3090 Ti with driver 580). PyTorch's native sdpa handles
+    # those position IDs correctly and is still hardware-accelerated.
+    _qwen_vl_models = ("Qwen2-VL", "Qwen2.5-VL", "Qwen3-VL", "Qwen3.5", "Qwen3_5")
+    if any(_contains_token(model_source, tok) for tok in _qwen_vl_models):
         return "sdpa"
 
     if has_flash_attn():

--- a/tests/test_logging_payload.py
+++ b/tests/test_logging_payload.py
@@ -19,6 +19,11 @@ def generic_index(client, sname, index_json):
 
 
 def test_logging_payload(client):
+    # Guard against stale artifacts from a previously interrupted run
+    # (e.g. agent node went offline mid-test so the finally block never ran).
+    client.delete("/v1/app/test_logging_payload")
+    shutil.rmtree("test_logging_payload_2", ignore_errors=True)
+
     try:
         # Step 1: Validate base endpoint
         response = client.get("/v1/info")


### PR DESCRIPTION
## Summary

- `flash_attention_2` with the varlen kernel silently produces garbage logits (→ all-`!` output, max_new_tokens long) for Qwen VL models that use 3D mrope position IDs, on certain GPU/driver combinations (confirmed on RTX 3090 Ti with driver 580.x)
- Extends the existing Qwen3.5 `sdpa` workaround in `attention.py` to also cover Qwen2-VL and Qwen2.5-VL
- Adds a pre-test cleanup in `test_logging_payload` to guard against stale artifacts left by an interrupted CI run (neptune05t node went offline mid-test in several recent CI logs)

## Root cause

`resolve_attn_implementation()` was returning `flash_attention_2` for Qwen2-VL whenever `flash_attn` was installed. On the CI machine (RTX 3090 Ti, driver 580.159.03), the flash-attn varlen kernel produces incorrect attention outputs without raising an exception — the model then generates the `!` token deterministically for every step until `max_new_tokens` (2048). PyTorch's native `sdpa` implementation handles the 3D mrope position IDs correctly and is still hardware-accelerated.

## Test plan

- [x] `test_logging_payload` passes in isolation (36s, sdpa)
- [x] Full CI sequence passes locally: `test_upload` → `test_multiple_creation` → `test_logging_payload` → `test_base_ci` (140s, 5 passed)