### PR TITLE
fix: reset default gpu_ids to 0 in vrag configs to fix pipeline CI

### DIFF
--- a/src/colette/config/vrag_default.json
+++ b/src/colette/config/vrag_default.json
@@ -9,7 +9,7 @@
             "lib": "hf",
             "rag": {
                 "embedding_model": "Alibaba-NLP/gme-Qwen2-VL-2B-Instruct",
-                "gpu_id": 2,
+                "gpu_id": 0,
                 "top_k": 4,
                 "retrieval_mode": "embedding_retrieval",
                 "text_search_engine_top_k": 4,
@@ -27,7 +27,7 @@
         },
         "llm": {
             "source": "Qwen/Qwen3.5-9B",
-            "gpu_ids": [3],
+            "gpu_ids": [0],
             "image_width": 320,
             "image_height": 480,
             "adjust_aspect_ratio": true,                        

--- a/src/colette/config/vrag_default_index.json
+++ b/src/colette/config/vrag_default_index.json
@@ -6,7 +6,7 @@
                 "dpi": 300
             },
             "rag": {
-                "gpu_id": 2,
+                "gpu_id": 0,
                 "retrieval_mode": "embedding_retrieval",
                 "text_search_engine_top_k": 4,
                 "text_search_engine_fields": ["content", "source"],

--- a/tests/test_pipeline_python_api_integration.py
+++ b/tests/test_pipeline_python_api_integration.py
@@ -70,6 +70,7 @@ def pipeline_context(tmp_path):
     index_config["parameters"]["input"]["data"] = [str(root / "tests" / "data_pdf1")]
     index_config["parameters"]["input"]["rag"]["reindex"] = True
     index_config["parameters"]["input"]["rag"]["index_protection"] = False
+    index_config["parameters"]["input"]["rag"]["gpu_id"] = 0
 
     return {
         "app_name": app_name,

--- a/tests/test_pipeline_tantivy_integration.py
+++ b/tests/test_pipeline_tantivy_integration.py
@@ -66,6 +66,7 @@ def text_search_engine_context(tmp_path):
     index_config["parameters"]["input"]["data"] = [str(_ROOT / "tests" / "data_pdf1")]
     index_config["parameters"]["input"]["rag"]["reindex"] = True
     index_config["parameters"]["input"]["rag"]["index_protection"] = False
+    index_config["parameters"]["input"]["rag"]["gpu_id"] = 0
 
     return {
         "create": create_config,


### PR DESCRIPTION
## Summary

- `vrag_default.json` and `vrag_default_index.json` had `gpu_id: 2` / `gpu_ids: [3]` hardcoded for a dev machine with 4 GPUs
- In CI with `CUDA_VISIBLE_DEVICES=0` or `=1`, only logical device 0 is visible — `LayoutDetector` crashed with `CUDA error: invalid device ordinal` when trying to `.to(cuda:2)`
- Reset both config files to `gpu_id: 0` / `gpu_ids: [0]` (correct single-GPU defaults; multi-GPU users override per their setup)
- Add explicit `gpu_id=0` overrides in both pipeline test fixtures as a defensive measure

## What passes after this fix

- `test_pipeline_python_api_create_index_predict[Qwen/Qwen3-VL-Embedding-2B]` ✓
- `test_pipeline_python_api_create_index_predict[Alibaba-NLP/gme-Qwen2-VL-2B-Instruct]` ✓
- `test_pipeline_python_api_index_invalid_data_path` ✓
- `test_embedding_mode_has_no_text_context` ✓

## Note on remaining Tantivy failures

`test_text_search_engine_retrieval_mode_at_index_time` and `test_text_search_engine_per_request_override` still fail with `Expected 'text_context' key in sources`. This is a **pre-existing functional issue** with the Tantivy text search integration — those tests were only hidden behind the device ordinal crash before. They are not caused by this PR.