### PR TITLE
fix: cap embedding image size to 640x960 in multi-image e2e tests

### DIFF
--- a/tests/test_base_img_hf_multi.py
+++ b/tests/test_base_img_hf_multi.py
@@ -23,6 +23,8 @@ def test_hf_multiple_images(temp_dir, client):
                     "top_k": 2,
                     "ragm": {
                         "layout_detection": False,
+                        "image_width": 640,
+                        "image_height": 960,
                     },
                 },
                 "template": {
@@ -139,6 +141,8 @@ def test_hf_multiple_images_crops(temp_dir, client):
                     "top_k": 4,
                     "ragm": {
                         "layout_detection": True,
+                        "image_width": 640,
+                        "image_height": 960,
                     },
                 },
                 "template": {
@@ -384,6 +388,8 @@ def test_hf_multiple_images_with_duplicates(temp_dir, client):
                     "gpu_id": 0,
                     "ragm": {
                         "layout_detection": False,
+                        "image_width": 640,
+                        "image_height": 960,
                     },
                 },
                 "template": {


### PR DESCRIPTION
## Summary

- The `gme-Qwen2-VL-2B` embedding model uses eager attention (O(n²) in sequence length) in its visual encoder. Test images in `data_img2` and `data_dup` are 1892×2834 px — at native resolution, a batch of 2 pages produces ~6767 visual tokens each, and the attention tensor `(B=2, H=16, S=6767)` requires ~5.86 GiB. When the LLM is also in VRAM (~11 GiB total already), this exceeds the Quadro RTX 5000's 16 GiB capacity.
- Adds `ragm.image_width: 640, image_height: 960` to the three active multi-image e2e tests (`test_hf_multiple_images`, `test_hf_multiple_images_crops`, `test_hf_multiple_images_with_duplicates`). This triggers the PIL thumbnail in `ImageEmbeddingFunction.__call__` before `process_vision_info`, reducing each page from 1892×2834 to ~640×958. Visual tokens drop from ~6767 to ~765, cutting peak attention memory from 5.86 GiB to ~75 MiB.

## Test plan

- [ ] `ci-e2e` passes on GPU 1 (Quadro RTX 5000, 16 GiB) — OOM no longer occurs in `test_hf_multiple_images` and `test_hf_multiple_images_crops`
- [ ] `test_hf_multiple_images_with_duplicates` (3 images, previously worse than the other two) also stays within memory limits
- [ ] Existing assertions (`"Rapport" in output`) still pass — 640×960 is sufficient resolution for these document pages