### PR TITLE
fix: tantivy text_context key drop and single-image OOM on 16 GiB GPU

### DIFF
--- a/src/colette/apidata.py
+++ b/src/colette/apidata.py
@@ -47,7 +47,7 @@ class RAGMultimodalObj(BaseModel):
     image_height: int | None = None
     """ V-RAG image height """
     auto_scale_for_font: bool = False
-    """ Whether to auto scale the images to that fonts are best readable by multimodal LLMs (warning: bypasses image_width and image_height) """
+    """ Whether to auto scale the images so that fonts are best readable by multimodal LLMs; image_width and image_height still apply as an upper-bound cap after auto-scaling """
     min_font_size: int = 24  # value empirically obtained for qwen2vl2b, in pixels
     """ Min font size below which multimodal LLMs OCR capabilities degrade, empirically evaluated """
     filter_width: int = -1

--- a/src/colette/backends/hf/hflib.py
+++ b/src/colette/backends/hf/hflib.py
@@ -145,7 +145,7 @@ class HFLib(LLMLib):
 
             context.append(source)
         tsources = {"context": context}
-        if docs_source.get("text_context"):
+        if "text_context" in docs_source:
             tsources["text_context"] = docs_source["text_context"]
 
         # save streamer object for upcoming streaming call

--- a/src/colette/backends/hf/rag/rag_img.py
+++ b/src/colette/backends/hf/rag/rag_img.py
@@ -351,12 +351,10 @@ class ImageEmbeddingFunction(EmbeddingFunction):
             else:
                 label = None
             if "PIL" in str(type(item)):  # or "Png" in str(type(item)) or "Jpeg" in str(type(item)):
-                if not self.rag_auto_scale_for_font and self.rag_image_width and self.rag_image_height:
+                if self.rag_image_width and self.rag_image_height:
                     width, height = item.size
                     if width > self.rag_image_width or height > self.rag_image_height:
                         item.thumbnail((self.rag_image_width, self.rag_image_height))
-                if self.rag_auto_scale_for_font and (self.rag_image_width or self.rag_image_height):
-                    self.logger.warn("Auto scaling for font is enabled. image_width and image_height are ignored")
                 question = "What is the content of this image?"
                 if label:
                     question = "This image has a " + label + ". " + question
@@ -406,7 +404,7 @@ class ImageEmbeddingFunction(EmbeddingFunction):
             else:
                 label = None
             if "PIL" in str(type(item)):  # or "Png" in str(type(item)) or "Jpeg" in str(type(item)):
-                if not self.rag_auto_scale_for_font and self.rag_image_width and self.rag_image_height:
+                if self.rag_image_width and self.rag_image_height:
                     width, height = item.size
                     if width > self.rag_image_width or height > self.rag_image_height:
                         item.thumbnail((self.rag_image_width, self.rag_image_height))

--- a/tests/test_base_img_hf_single.py
+++ b/tests/test_base_img_hf_single.py
@@ -32,6 +32,8 @@ def test_hf_single_image(temp_dir, client):
                     "top_k": 1,
                     "ragm": {
                         "layout_detection": False,
+                        "image_width": 640,
+                        "image_height": 960,
                     },
                 },
                 "template": {
@@ -119,7 +121,7 @@ def test_hf_single_image_rephrasing(temp_dir, client):
                     "embedding_lib": "huggingface",
                     "embedding_model": "Alibaba-NLP/gme-Qwen2-VL-2B-Instruct",
                     "top_k": 1,
-                    "ragm": {"layout_detection": False},
+                    "ragm": {"layout_detection": False, "image_width": 640, "image_height": 960},
                 },
                 "template": {
                     "template_prompt": "Tu es un assistant de réponse à des questions. Question: {question} Réponse: ",
@@ -206,6 +208,8 @@ def test_hf_single_image_autoscale(temp_dir, client):
                     "ragm": {
                         "layout_detection": False,
                         "auto_scale_for_font": True,
+                        "image_width": 640,
+                        "image_height": 960,
                     },
                 },
                 "template": {

--- a/tests/test_pipeline_tantivy_integration.py
+++ b/tests/test_pipeline_tantivy_integration.py
@@ -103,7 +103,7 @@ def test_text_search_engine_retrieval_mode_at_index_time(text_search_engine_cont
         query = APIData(
             **{
                 "parameters": {
-                    "input": {"message": "What is the title of the document?"}
+                    "input": {"message": "Ariane satellite"}
                 }
             }
         )
@@ -153,7 +153,7 @@ def test_text_search_engine_per_request_override(text_search_engine_context):
             **{
                 "parameters": {
                     "input": {
-                        "message": "What is the title of the document?",
+                        "message": "Ariane satellite",
                         "rag": {"retrieval_mode": "text_search_retrieval"},
                     }
                 }


### PR DESCRIPTION
Summary

- hflib.py: if docs_source.get("text_context"): is falsy when Tantivy returns [], silently dropping the key from sources. Changed to if "text_context" in docs_source: so downstream assertions always see the field.
- test_pipeline_tantivy_integration.py: query "What is the title of the document?" is English; fusee_ariane_5.pdf is entirely French — BM25 returns zero hits. Changed to "Ariane satellite" which appears in the indexed text.
- rag_img.py: auto_scale_for_font=True bypassed the image_width/height thumbnail cap. Removed the guard in both HF and vLLM embedding paths so dimensions act as a hard upper bound after auto-scaling.
- test_base_img_hf_single.py: added image_width: 640, image_height: 960 to ragm in all three single-image tests. At full resolution (1892×2834), gme-Qwen2-VL generates ~2.93 GiB of attention; with LLM + embedder baseline (~11 GiB) this OOMs on GPU 1 (16 GiB Quadro RTX 5000).

Test plan
- ci-integration: test_text_search_engine_retrieval_mode_at_index_time[text_search_retrieval], [hybrid], and test_text_search_engine_per_request_override should pass — Tantivy now returns hits for "Ariane satellite" and the key is no longer dropped
- ci-e2e on GPU 1 (16 GiB): test_hf_single_image, test_hf_single_image_rephrasing, test_hf_single_image_autoscale should pass — images capped at 640×960 before embedding