### PR TITLE
fix: add embedding image size cap to reindex tests to prevent OOM on 16 GiB GPU

### DIFF
--- a/tests/test_base_img_reindex.py
+++ b/tests/test_base_img_reindex.py
@@ -39,6 +39,8 @@ def test_create_app_and_index(temp_dir, client):
                     "top_k": 2,
                     "ragm": {
                         "layout_detection": False,
+                        "image_width": 640,
+                        "image_height": 960,
                     },
                 },
             },
@@ -149,6 +151,8 @@ def test_create_app_twice(temp_dir, client):
                     "top_k": 2,
                     "ragm": {
                         "layout_detection": False,
+                        "image_width": 640,
+                        "image_height": 960,
                     },
                 },
                 "template": {
@@ -260,7 +264,7 @@ def test_index_first(temp_dir, client):
                     "embedding_lib": "huggingface",
                     "embedding_model": "Alibaba-NLP/gme-Qwen2-VL-2B-Instruct",
                     "top_k": 2,
-                    "ragm": {"layout_detection": False},
+                    "ragm": {"layout_detection": False, "image_width": 640, "image_height": 960},
                 },
                 "template": {
                     "template_prompt": "Tu es un assistant de réponse à des questions. Question: {question} Réponse: ",
@@ -331,6 +335,8 @@ def test_create_app_and_multiple_index(temp_dir, client):
                     "top_k": 2,
                     "ragm": {
                         "layout_detection": False,
+                        "image_width": 640,
+                        "image_height": 960,
                     },
                 },
                 "template": {


### PR DESCRIPTION
Summary

- test_base_img_reindex.py: all four tests (test_create_app_and_index, test_create_app_twice, test_index_first, test_create_app_and_multiple_index) call gme-Qwen2-VL-2B-Instruct on data_img1 (1892x2834 px) with no ragm image dimension limits. At full resolution the visual encoder's eager attention tries to allocate ~5.97 GiB; with LLM + embedder already occupying ~11.7 GiB this exceeds the Quadro RTX 5000's 15.55 GiB on GPU 1.

- Added image_width: 640, image_height: 960 to the ragm section of all four tests -- the same fix applied to test_base_img_hf_single.py and test_base_img_hf_multi.py in earlier PRs.

Test plan

- ci-e2e on GPU 1 (16 GiB): test_create_app_and_index and test_create_app_twice should no longer OOM during indexing