### PR TITLE
fix: replace deprecated chromadb.Client() with PersistentClient/EphemeralClient

### DIFF
--- a/src/colette/backends/coldb/coldb.py
+++ b/src/colette/backends/coldb/coldb.py
@@ -69,15 +69,14 @@ class ColDB:
 
         self.persist_directory = persist_directory
         if self.persist_directory:
-            _client_settings = chromadb.config.Settings(
-                is_persistent=True, anonymized_telemetry=False
+            self._client = chromadb.PersistentClient(
+                path=str(persist_directory),
+                settings=chromadb.config.Settings(anonymized_telemetry=False, allow_reset=True),
             )
-            _client_settings.persist_directory = str(persist_directory)
         else:
-            _client_settings = chromadb.config.Settings(anonymized_telemetry=False)
-        self._client_settings = _client_settings
-        self._client_settings.allow_reset = True
-        self._client = chromadb.Client(self._client_settings)
+            self._client = chromadb.EphemeralClient(
+                settings=chromadb.config.Settings(anonymized_telemetry=False, allow_reset=True),
+            )
         self._client.clear_system_cache()
 
         if recreate and self._client.count_collections() != 0:

--- a/src/colette/backends/hf/rag/rag_img.py
+++ b/src/colette/backends/hf/rag/rag_img.py
@@ -643,12 +643,9 @@ class RAGImg:
         self.rag_embedding_lib = ad.rag.embedding_lib
         
         if self.rag_indexdb_lib == "chromadb":
-            self.rag_indexdb_client = chromadb.Client(
-                Settings(
-                    is_persistent=True,
-                    persist_directory=str(self.indexpath),
-                    anonymized_telemetry=False,
-                )
+            self.rag_indexdb_client = chromadb.PersistentClient(
+                path=str(self.indexpath),
+                settings=Settings(anonymized_telemetry=False),
             )
         else:
             self.rag_indexdb_client = None


### PR DESCRIPTION
chromadb.Client(Settings(is_persistent=True, persist_directory=...)) crashes with the new Rust-backend chromadb version:

AttributeError: 'RustBindingsAPI' object has no attribute 'bindings'

This affected two places:

src/colette/backends/hf/rag/rag_img.py (line 646) - called when loading an existing chromadb index directory, which broke test_create_app_twice and test_chat.

src/colette/backends/coldb/coldb.py (line 80) - same deprecated pattern in the ColBERT backend.

Fix: use chromadb.PersistentClient(path=..., settings=Settings(...)) when a persist directory is set, and chromadb.EphemeralClient(...) for in-memory usage. Both are the modern API that works with existing on-disk databases.