### PR TITLE
Fix the stale flash-attn assertion in create_venv_colette.sh

### DIFF
--- a/create_venv_colette.sh
+++ b/create_venv_colette.sh
@@ -26,25 +26,27 @@ COLETTE_CUDA_SHORT="${cuda_short}" bash scripts/install_python_deps.sh
 
 echo "Running flash-attn compatibility smoke check..."
 python - <<'PY'
-import importlib.util
+from colette.backends.hf.attention import has_flash_attn, resolve_attn_implementation
 
-from colette.backends.hf.attention import resolve_attn_implementation
+# Qwen VL models use 3D mrope position IDs, which flash-attn's varlen kernel
+# mishandles, so attention.py routes the whole family to sdpa. Everything else
+# uses flash_attention_2 when flash-attn is importable.
+qwen35 = resolve_attn_implementation("Qwen/Qwen3.5-9B")
+qwen2vl = resolve_attn_implementation("Qwen/Qwen2-VL-7B-Instruct")
+other = resolve_attn_implementation("meta-llama/Meta-Llama-3-8B")
+print(f"has_flash_attn={has_flash_attn()}")
+print(f"resolved_attn_implementation(Qwen3.5)={qwen35}")
+print(f"resolved_attn_implementation(Qwen2-VL)={qwen2vl}")
+print(f"resolved_attn_implementation(non-Qwen-VL)={other}")
 
-has_flash = importlib.util.find_spec("flash_attn") is not None
-attn_impl = resolve_attn_implementation("Qwen/Qwen3.5-9B")
-attn_impl_other = resolve_attn_implementation("Qwen/Qwen2-VL-7B-Instruct")
-print(f"flash_attn_installed={has_flash}")
-print(f"resolved_attn_implementation(Qwen3.5)={attn_impl}")
-print(f"resolved_attn_implementation(other)={attn_impl_other}")
-
-# Qwen3.5 uses sdpa (PyTorch native) to avoid flash-attn varlen bug with mrope.
-# All other models use flash_attention_2 when flash_attn is installed.
-if not has_flash:
+if not has_flash_attn():
     raise SystemExit("flash-attn is not installed")
-if attn_impl != "sdpa":
-    raise SystemExit(f"Expected sdpa for Qwen3.5, got {attn_impl!r}")
-if attn_impl_other != "flash_attention_2":
-    raise SystemExit(f"Expected flash_attention_2 for other models, got {attn_impl_other!r}")
+if qwen35 != "sdpa":
+    raise SystemExit(f"Expected sdpa for Qwen3.5, got {qwen35!r}")
+if qwen2vl != "sdpa":
+    raise SystemExit(f"Expected sdpa for Qwen2-VL, got {qwen2vl!r}")
+if other != "flash_attention_2":
+    raise SystemExit(f"Expected flash_attention_2 for non-Qwen-VL models, got {other!r}")
 PY
 
 python -m pip check


### PR DESCRIPTION
# Fix the stale flash-attn assertion in create_venv_colette.sh

`create_venv_colette.sh` currently fails on every machine, regardless of whether
the environment is fine. Its smoke check asserts:

```python
attn_impl_other = resolve_attn_implementation("Qwen/Qwen2-VL-7B-Instruct")
...
if attn_impl_other != "flash_attention_2":
    raise SystemExit(...)
```

That stopped being true in `4ee251f` (2026-07-06, *"use sdpa attention for all
Qwen VL models to prevent flash-attn crashes"*), which added the whole Qwen VL
family — `Qwen2-VL` included — to the sdpa list in `attention.py`.
`create_venv_colette.sh` was last touched 2026-06-24, before that change, so the
assertion has been wrong ever since and takes the bootstrap down with it.

Verified against the current module:

```
OLD: Qwen2-VL -> 'sdpa' | expected flash_attention_2 -> FAIL
NEW: non-Qwen -> 'flash_attention_2'                 -> PASS
NEW: Qwen2-VL -> 'sdpa'                              -> PASS
```

## Changes

- Assert the contract `attention.py` actually implements: Qwen VL models resolve
  to `sdpa`, and a non-Qwen-VL model resolves to `flash_attention_2` when
  flash-attn is importable. `Qwen2-VL` moves to the sdpa case, and
  `meta-llama/Meta-Llama-3-8B` becomes the `flash_attention_2` probe.
- Call `has_flash_attn()` instead of testing `find_spec("flash_attn")` directly.
  That is the helper `resolve_attn_implementation` itself uses, and it also
  catches a flash-attn that is present in site-packages but fails to import —
  precisely the case this check exists to detect.

The equivalent fix already landed for `create_venv_colette_DGX.sh` in #90; this
brings the standard installer in line.

## Scope

One file, and only the smoke-check block. No dependency, install, or runtime
behaviour changes. The check can now only fail for a genuinely broken
environment, not for a correct one.

## Caveat

Verified by evaluating the assertions against `colette.backends.hf.attention` in
a working venv — the old ones fail, the new ones pass. The full script was **not**
executed end to end here: this is a DGX Spark (aarch64), and `pyproject.toml`
pins `faiss-gpu-cu12` and a torch line that has no aarch64 build, so
`create_venv_colette.sh` cannot complete on this box by design. Worth one full
run on an x86 server before merge.