### PR TITLE
Feat/dgx qwen3.8 27b

### DIFF
--- a/create_venv_colette_DGX.sh
+++ b/create_venv_colette_DGX.sh
@@ -70,18 +70,17 @@ pip install "setuptools>=77.0.3,<81.0.0" wheel "packaging>=23.2,<26.0.0"
 echo "Clearing pip cache..."
 pip cache purge
 
-# Select torch/flash-attn versions based on detected CUDA major version
+# torch must match vllm 0.19.0's torch==2.10.0 pin regardless of CUDA version.
+# Installing anything else means `pip install -e .` replaces torch during the
+# colette install, which both undoes the CUDA-specific wheel selected here and
+# invalidates the flash-attn built against it. Only the wheel index varies.
+TORCH_VERSION="2.10.0"
+FLASH_ATTN_VERSION="2.8.3"
 cuda_major=$(echo "$cuda_version" | cut -d. -f1)
 if [ "$cuda_major" -ge 13 ]; then
-    # Must match vllm 0.19.0's torch==2.10.0 pin, or installing colette drags in
-    # a different torch and invalidates the flash-attn build below.
-    TORCH_VERSION="2.10.0"
     TORCH_INDEX_URL="https://download.pytorch.org/whl/cu130"
-    FLASH_ATTN_VERSION="2.8.3"
 else
-    TORCH_VERSION="2.7.0"
-    TORCH_INDEX_URL="https://download.pytorch.org/whl/test/cu128"
-    FLASH_ATTN_VERSION="2.5.6"
+    TORCH_INDEX_URL="https://download.pytorch.org/whl/cu128"
 fi
 
 echo "Installing torch with CUDA support from: $TORCH_INDEX_URL"

--- a/create_venv_colette_DGX.sh
+++ b/create_venv_colette_DGX.sh
@@ -297,6 +297,17 @@ fi
 # Install colette with extras (flash-attn already satisfied above)
 pip install -e "$SCRIPT_DIR[dev,trag]"
 
+# Point the examples at the DGX config by default. transformers 4.x cannot load
+# the qwen3_5 architecture, so vrag_default.json (lib: huggingface) fails here;
+# vrag_default_DGX.json serves the same model through vLLM. Written into the
+# venv so anything using this interpreter picks it up -- terminals and notebook
+# kernels alike -- while an explicit override still wins.
+if ! grep -q "COLETTE_VRAG_CONFIG" "$ACTIVATE_FILE"; then
+    echo "" >> "$ACTIVATE_FILE"
+    echo "# Colette DGX default config" >> "$ACTIVATE_FILE"
+    echo "export COLETTE_VRAG_CONFIG=\"\${COLETTE_VRAG_CONFIG:-$SCRIPT_DIR/src/colette/config/vrag_default_DGX.json}\"" >> "$ACTIVATE_FILE"
+fi
+
 # Verify flash-attn installation
 if python -c "import torch; import flash_attn" 2>/dev/null; then
     echo "✓ flash-attn installed successfully!"

--- a/docs/source/users/get_started_DGX_machine.md
+++ b/docs/source/users/get_started_DGX_machine.md
@@ -4,21 +4,32 @@
 
 Make sure your system meets the following requirements:
 
-* **Python** >= 3.12
-* **CUDA** >= 12.1
-* **GPU**: >= 24 GB
-* **RAM**: >= 16 GB
-* **Disk space**: >= 50 GB
+* **Python** 3.12 (the bootstrap script requires exactly 3.12)
+* **CUDA** >= 12.8, CUDA 13 recommended
+* **Memory**: >= 80 GB available to the GPU
+* **Disk space**: >= 120 GB
+* **Architecture**: x86_64 or aarch64
 
-NOTE: Colette requires a GPU with at least 24GB of VRAM to run the default models. If you have less VRAM, you can try to change the models to lighter ones in the configuration files, but performance may be impacted.
+The memory and disk figures are driven by the DGX default model,
+`Qwen/Qwen3.8-27B`: roughly 52 GB of weights to download, ~51 GiB resident once
+loaded, plus KV cache. On a DGX Spark (GB10, 121 GB unified memory) the model
+occupies 51.1 GiB and leaves 17.1 GiB of KV cache at the config's
+`vllm_memory_utilization` of 0.6. The virtual environment itself is ~11 GB, and
+FAISS is compiled from source during installation.
 
-Also the default config file is `vrag_default_lite.json` which is designed to run on 24GB VRAM GPUs. If you have multiples GPUs, you can try `vrag_default.json` which uses larger models and should provide better results and also needs multiple GPUs
+To run on less memory, point `source` in `src/colette/config/vrag_default_DGX.json`
+at a smaller model of the same family and lower `context_size`.
+
+### A note on ARM
+
+A DGX Spark is aarch64, so it is both "DGX" and "ARM". Use **this** guide and
+`create_venv_colette_DGX.sh` for it. `create_venv_colette_ARM.sh` and
+[Get Started on ARM Machine](get_started_ARM_machine.md) target other ARM boards
+and pin an older dependency set.
 
 ## Docker with DGX support
 
 You can use the standard Docker workflow from [Get Started](get_started.md). For DGX-specific source setup (CUDA-aware dependency selection), follow the installation steps below.
-
-If you are running on ARM, see [Get Started on ARM Machine](get_started_ARM_machine.md).
 
 ## Installation from Source
 
@@ -41,12 +52,44 @@ source venv_colette/bin/activate
 
 NOTE: This process may take a while, as there are many dependencies to install and some of them require compilation.
 
+### Which configuration to use
+
+**Use `src/colette/config/vrag_default_DGX.json` on DGX.** The bootstrap script
+writes `COLETTE_VRAG_CONFIG` into the virtual environment's `activate`, so once
+the environment is active the examples and the notebook pick it up
+automatically. Nothing to export by hand:
+
+```bash
+source venv_colette/bin/activate
+echo $COLETTE_VRAG_CONFIG
+# /path/to/colette/src/colette/config/vrag_default_DGX.json
+```
+
+The other shipped configs do **not** work here. `vrag_default.json` and
+`vrag_default_lite.json` serve their LLM through the `huggingface` backend, and
+the DGX dependency set pins `transformers>=4.56,<5`, which cannot load the
+`qwen3_5` architecture those configs use:
+
+```
+The checkpoint you are trying to load has model type `qwen3_5`
+but Transformers does not recognize this architecture.
+```
+
+`vrag_default_DGX.json` serves the same family through vLLM, which does
+implement it, and additionally caps the context at 8192, holds vLLM to 60% of
+GPU memory, and pins layout detection to CPU so indexing stays off the GPU
+memory budget.
+
+To override the default, set `COLETTE_VRAG_CONFIG` yourself or pass
+`--config-file` to the CLI.
+
+
 ##### Index the data
 
 Let's index a PDF slidedeck from docs/pdf
 
 ```bash
-colette_cli index --app-dir app_colette --data-dir docs/pdf/ --config-file src/colette/config/vrag_default_lite.json
+colette_cli index --app-dir app_colette --data-dir docs/pdf/ --config-file src/colette/config/vrag_default_DGX.json
 ```
 
 ##### Test with a question
@@ -91,7 +134,10 @@ models_dir = os.path.join(colette_root, 'models') # where the models are located
 app_name = 'app_colette' # name of the app
 
 # read the configuration file
-config_file = os.path.join(colette_root, 'src/colette/config/vrag_default_lite.json')
+config_file = os.environ.get(
+    'COLETTE_VRAG_CONFIG',
+    os.path.join(colette_root, 'src/colette/config/vrag_default_DGX.json'),
+)
 index_file = os.path.join(colette_root, 'src/colette/config/vrag_default_index.json')
 
 with open(config_file, 'r') as f:
@@ -148,3 +194,39 @@ for item in response.sources['context']:
     image.save(image_filename)
     print(f"Image saved as: {image_filename}")
 ```
+
+## Notes and troubleshooting
+
+**The first run downloads ~52 GB of model weights.** Expect a long wait before
+anything appears to happen. The download is not resumable in practice — the
+Hugging Face `xet` transfer discards partial chunks if the process is
+interrupted — so let it finish. Pre-warming the cache once on a machine saves
+everyone else the wait.
+
+**Run one instance at a time.** vLLM reserves `vllm_memory_utilization` of GPU
+memory up front, so two concurrent services will not fit. Two processes also
+share `app_colette/`'s ChromaDB store, which surfaces as:
+
+```
+InternalError: Database error: (code: 1032) attempt to write a readonly database
+```
+
+**A saved app config overrides `COLETTE_VRAG_CONFIG`.** Once a service has been
+created, `<app_dir>/config.json` exists and takes precedence, so query-only
+reruns keep the settings they were indexed with. A stale app directory from a
+failed run therefore pins you to the wrong model. To start clean:
+
+```bash
+rm -rf app_colette
+```
+
+**`service_create` does not raise on failure.** It returns an `APIResponse` with
+every field set to `None`, and the underlying error appears only in the logs. The
+next call then fails with a misleading `service <name> not found`. If you see
+that, look at the log output of the *create* step, not the failing call.
+
+**Reasoning traces are not shown.** `Qwen3.8-27B` is a thinking model: it reasons
+before answering. Colette keeps the reasoning — it is what grounds the answer —
+but strips it from the returned text, so `response.output` holds the final answer
+only.
+

--- a/src/colette/backends/hf/attention.py
+++ b/src/colette/backends/hf/attention.py
@@ -28,7 +28,7 @@ def resolve_attn_implementation(model_source: str | None = None) -> str:
     # silently produce garbage outputs (all-! tokens) depending on GPU/driver
     # (confirmed on RTX 3090 Ti with driver 580). PyTorch's native sdpa handles
     # those position IDs correctly and is still hardware-accelerated.
-    _qwen_vl_models = ("Qwen2-VL", "Qwen2.5-VL", "Qwen3-VL", "Qwen3.5", "Qwen3_5")
+    _qwen_vl_models = ("Qwen2-VL", "Qwen2.5-VL", "Qwen3-VL", "Qwen3.5", "Qwen3_5", "Qwen3.8")
     if any(_contains_token(model_source, tok) for tok in _qwen_vl_models):
         return "sdpa"
 

--- a/src/colette/backends/hf/hfmodel.py
+++ b/src/colette/backends/hf/hfmodel.py
@@ -677,7 +677,6 @@ class HFModel(LLMModel):
                             mm_processor_kwargs={
                                 "min_pixels": 1 * 28 * 28,
                                 "max_pixels": 2560 * 28 * 28,
-                                "max_model_len": self.vllm_context_size,
                             },
                             sampling_params=sampling_params,
                         )

--- a/src/colette/backends/hf/hfmodel.py
+++ b/src/colette/backends/hf/hfmodel.py
@@ -45,6 +45,25 @@ def stitch_images_vertically(image_list):
     return stitched_image
 
 
+def strip_reasoning_trace(text: str) -> str:
+    """Drop a Qwen-style reasoning trace, keeping only the final answer.
+
+    Thinking models emit the trace first, terminated by </think>. The opening
+    <think> is pre-filled by the chat template, so it never appears in the
+    generated text -- the trace simply runs from the start of the output.
+
+    If no </think> is present the text is returned unchanged: either the model
+    did not think at all (nothing to strip), or generation hit the token limit
+    mid-trace, in which case the partial trace is still more useful to return
+    than an empty string.
+    """
+    marker = "</think>"
+    idx = text.rfind(marker)
+    if idx == -1:
+        return text
+    return text[idx + len(marker) :].lstrip()
+
+
 class HFModel(LLMModel):
     def __init__(self):
         super().__init__()
@@ -668,6 +687,17 @@ class HFModel(LLMModel):
                             sampling_params=sampling_params,
                         )
                     decoded = "".join([o.outputs[0].text for o in outputs])
+                    # Thinking models reason before answering; the caller wants
+                    # the answer only.
+                    stripped = strip_reasoning_trace(decoded)
+                    if stripped:
+                        decoded = stripped
+                    else:
+                        self.logger.warning(
+                            "reasoning trace closed with no answer after it; "
+                            "returning the raw output. Consider raising "
+                            "max_tokens or context_size."
+                        )
                 elif self.llm_type == "vllm_client":
                     decoded = self.llm.chat(messages, max_new_tokens)
 

--- a/src/colette/backends/hf/hfmodel.py
+++ b/src/colette/backends/hf/hfmodel.py
@@ -251,7 +251,10 @@ class HFModel(LLMModel):
                 self.llm_subtype = "qwen25-vl"
             elif "Qwen3-VL" in self.llm_source:
                 self.llm_subtype = "qwen3-vl"
-            elif "Qwen3.5" in self.llm_source or "Qwen3_5" in self.llm_source:
+            elif any(tok in self.llm_source for tok in ("Qwen3.5", "Qwen3_5", "Qwen3.8")):
+                # Qwen3.8 ships the same architecture as Qwen3.5
+                # (model_type qwen3_5, Qwen3_5ForConditionalGeneration), so it
+                # shares the subtype and needs no separate handling.
                 self.llm_subtype = "qwen35-vl"
             elif "SmolVLM" in self.llm_source:
                 self.llm_subtype = "smolvlm"

--- a/src/colette/config/vrag_default_DGX.json
+++ b/src/colette/config/vrag_default_DGX.json
@@ -27,7 +27,7 @@
             "data": []
         },
         "llm": {
-            "source": "Qwen/Qwen3.5-9B",
+            "source": "Qwen/Qwen3.8-27B",
             "gpu_ids": [0],
             "context_size": 8192,
             "vllm_memory_utilization": 0.6,


### PR DESCRIPTION
# Move DGX to Qwen3.8-27B, return only the final answer, fix the DGX guide

Switches the DGX vRAG config to `Qwen/Qwen3.8-27B`, stops the model's reasoning
trace from leaking into the output, makes the DGX config the default on DGX, and
brings the DGX getting-started guide in line with what actually works there.

## Result

Verified on DGX Spark (GB10 sm_121, CUDA 13, aarch64, 121 GB unified memory):

| | Qwen3.5-9B | **Qwen3.8-27B** |
|---|---|---|
| Weights | 17.66 GiB | **51.1 GiB** |
| KV cache @ `0.6` | 51.33 GiB | **17.12 GiB** |
| Engine init | 68.2s | 61.8s |
| Notebook | 23/23 cells | **23/23 cells** |
| CLI | — | `index` **exit 0**, `chat` **exit 0** |

`vllm_memory_utilization` is unchanged at `0.6`; 17 GiB of KV cache is far more
than the 8192 context needs. Smoke suite: 59 passed, 3 deselected, 35.18%.

## The model swap

`Qwen3.8-27B` reports the **same architecture** as Qwen3.5-9B — `model_type:
qwen3_5`, `Qwen3_5ForConditionalGeneration` — so vLLM 0.19.0 already registers
it and **no dependency change was needed**. It is multimodal
(`image-text-to-text`), as the vRAG path requires.

Colette identifies models by string-matching the source name, though, and
`Qwen/Qwen3.8-27B` matched neither existing matcher:

- `hfmodel.py` tested for `"Qwen3.5"`/`"Qwen3_5"`, so the new source fell through
  to `else: raise LLMModelBadParamException("Unknown vllm source: ...")`
- `attention.py`'s `_qwen_vl_models` missed it too, so
  `resolve_attn_implementation` would have returned `flash_attention_2` for a
  Qwen VL model — exactly the mrope/varlen pairing that list exists to avoid

Both now recognise `Qwen3.8`, mapped onto the **existing `qwen35-vl` subtype**
because the subtype tracks the architecture family, not the marketing version.

## Only the final answer

Qwen thinking models emit their reasoning first, terminated by `</think>`; the
opening tag is pre-filled by the chat template, so answers began mid-thought with
"The user is asking…".

`disable_thinking` already exists but is gated on `llm_type == "qwen3-vl"` — the
HuggingFace path — and `llm_type` is `"vllm"` here, so it was **silently
ignored**.

Rather than turn thinking off, the model keeps reasoning and the trace is dropped
from the returned text: the reasoning is what produces the grounded E1–E6
answers. If no `</think>` is present the text is returned unchanged, covering both
a non-thinking model and a generation that hit the token limit mid-trace — a
partial trace beats an empty answer, and that case logs a warning pointing at
`max_tokens`/`context_size`.

## DGX config by default

The notebook picks its config from `COLETTE_VRAG_CONFIG`, which meant DGX users
had to remember to export it — and without it the notebook falls back to
`vrag_default.json`, whose `huggingface` backend cannot load `qwen3_5` at all:

```
The checkpoint you are trying to load has model type `qwen3_5`
but Transformers does not recognize this architecture.
```

The bootstrap now writes that variable into the venv's `activate`, beside the
`LD_LIBRARY_PATH` exports it already persists. It lives in the venv rather than
the repo, so DGX gets the right config in terminals and notebook kernels alike
while other machines are untouched, and `${COLETTE_VRAG_CONFIG:-...}` keeps an
explicit override winning.

## Documentation

The DGX guide did not merely drift — it **documented commands that cannot work**.
Both the CLI and Python examples used `vrag_default_lite.json`, which serves
`Qwen/Qwen3.5-4B` through the `huggingface` backend, so anyone following the
guide hit the `qwen3_5` error above.

- both examples now use `vrag_default_DGX.json`, with a new section on why the
  other shipped configs cannot work on DGX
- prerequisites were written for a 24 GB GPU: raised to **>= 80 GB** of
  GPU-visible memory and **>= 120 GB** of disk, measured (52 GB of weights,
  51.1 GiB resident, 11 GB venv), CUDA to >= 12.8 with 13 recommended
- the guide sent ARM readers elsewhere, which is wrong for a DGX Spark — it is
  aarch64, so it is both DGX and ARM. Added a note that this guide is the right
  one for it
- new troubleshooting section covering the failures actually hit while verifying:
  the large non-resumable download, concurrent runs colliding on ChromaDB
  (`attempt to write a readonly database`), a saved app config silently
  overriding `COLETTE_VRAG_CONFIG`, `service_create` returning an all-`None`
  response instead of raising, and that reasoning traces are stripped

## Two bugs found while reviewing

**CUDA 12 installed the wrong torch.** The bootstrap installed torch 2.7.0 there
while `pyproject_DGX.toml` pins `vllm==0.19.0`, which requires `torch==2.10.0`.
`pip install -e .` would therefore have replaced torch during the colette install,
undoing the CUDA-specific wheel and invalidating the flash-attn built against
2.7.0. torch and flash-attn versions are the same either way, so they are hoisted
out of the branch and only the wheel index varies (cu130 / cu128).

**`max_model_len` in `mm_processor_kwargs` never did anything.** vLLM says so on
every query — `"not a valid argument for this processor and will be ignored"`.
It is an engine argument, already passed correctly to the constructor. Removed.

## Impact on non-DGX machines

None, with one caveat. Three of the five changed files are DGX-only or docs. The
two shared files carry four changes:

| Change | Effect elsewhere |
|---|---|
| `Qwen3.8` in `_qwen_vl_models` | **None** — only matches sources containing `Qwen3.8` |
| `Qwen3.8` in subtype matcher | **None** — verified across 8 real sources, every prior result identical; strictly a superset |
| Removed `max_model_len` kwarg | **None** — vLLM was ignoring it |
| `strip_reasoning_trace` | Confined to the `llm_type == "vllm"` branch; a verified no-op on text without `</think>` |

The only other shipped config on the vLLM path is `trag_default.json` →
`Qwen/Qwen2.5-0.5B-Instruct`, whose chat template contains no `think` and no
`enable_thinking`, so there is nothing to strip.

**The caveat:** a *custom* config using `lib: vllm` with a thinking model will see
its output change — the trace disappears. That is the intended behaviour, but it
is a real change for that case, not a no-op.

## Caveats for the reviewer

- **The CUDA 12 torch change was not executed.** This machine is CUDA 13, so the
  cu128 path is reasoned from the published wheel index rather than run. The
  CUDA 13 path is unchanged and verified end to end.
- **First run downloads ~52 GB** and the Hugging Face `xet` transfer does not
  resume partial chunks. Pre-warming the model cache on the box is worthwhile.
- **Run one instance at a time.** vLLM reserves its memory budget up front, and
  two processes on one `app_colette/` ChromaDB store produce
  `attempt to write a readonly database`.
- **The ARM guide has the same stale prerequisites** (24 GB GPU, 50 GB disk) and
  the same unusable `vrag_default_lite.json` examples. Left alone — those claims
  cannot be verified from a DGX, and this PR is scoped to DGX.
- `vllm_context_size` is now assigned but unused; `vllm_max_model_len` is the
  effective value. Left in place rather than churn a public attribute.