### PR TITLE
feat(dgx): switch embedder to Qwen3-VL-Embedding-8B

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= $(if $(wildcard venv_colette/bin/python),venv_colette/bin/python,python3)
 PYTEST ?= $(PYTHON) -m pytest
 RUFF ?= $(PYTHON) -m ruff
-SMOKE_TESTS ?= tests/test_base_ci.py::test_info tests/test_embedding_loader.py tests/test_embedding_integration.py tests/test_services_smoke.py tests/test_http_openwebui_smoke.py tests/test_cli_smoke.py tests/test_jsonapi_helpers_smoke.py tests/test_kvstore_smoke.py tests/test_logger_smoke.py tests/test_jsonapi_service_smoke.py tests/test_core_services_smoke.py tests/test_apidata_rag_merge.py tests/test_retrieval_modes.py
+SMOKE_TESTS ?= tests/test_base_ci.py::test_info tests/test_embedding_loader.py tests/test_layout_detector_device.py tests/test_embedding_integration.py tests/test_services_smoke.py tests/test_http_openwebui_smoke.py tests/test_cli_smoke.py tests/test_jsonapi_helpers_smoke.py tests/test_kvstore_smoke.py tests/test_logger_smoke.py tests/test_jsonapi_service_smoke.py tests/test_core_services_smoke.py tests/test_apidata_rag_merge.py tests/test_retrieval_modes.py
 INTEGRATION_STABLE_TESTS ?= tests/test_upload.py tests/test_multiple_creation.py tests/test_logging_payload.py tests/test_base_ci.py::test_llamacpp_hf
 EVALUATION_TESTS ?= tests_optional/evaluation_contract/test_configs_contract.py tests_optional/evaluation_contract/test_hf_single_contract.py
 COV_MIN ?= 35

--- a/docs/source/users/get_started_DGX_machine.md
+++ b/docs/source/users/get_started_DGX_machine.md
@@ -6,19 +6,34 @@ Make sure your system meets the following requirements:
 
 * **Python** 3.12 (the bootstrap script requires exactly 3.12)
 * **CUDA** >= 12.8, CUDA 13 recommended
-* **Memory**: >= 80 GB available to the GPU
-* **Disk space**: >= 120 GB
+* **Memory**: >= 96 GB available to the GPU
+* **Disk space**: >= 140 GB
 * **Architecture**: x86_64 or aarch64
 
-The memory and disk figures are driven by the DGX default model,
-`Qwen/Qwen3.8-27B`: roughly 52 GB of weights to download, ~51 GiB resident once
-loaded, plus KV cache. On a DGX Spark (GB10, 121 GB unified memory) the model
-occupies 51.1 GiB and leaves 17.1 GiB of KV cache at the config's
-`vllm_memory_utilization` of 0.6. The virtual environment itself is ~11 GB, and
-FAISS is compiled from source during installation.
+The memory and disk figures are driven by two models, both resident at the same
+time: the generator `Qwen/Qwen3.8-27B` (~52 GB of weights to download, 51.1 GiB
+resident) and the embedder `Qwen/Qwen3-VL-Embedding-8B` (~16.3 GB to download,
+16.3 GB resident in bfloat16). The virtual environment adds ~11 GB and FAISS is
+compiled from source during installation.
+
+Measured on a DGX Spark (GB10, 121 GB unified memory) with the shipped config:
+
+| | |
+|---|---|
+| generator weights | 51.1 GiB |
+| KV cache at `vllm_memory_utilization` 0.5 | 5.23 GiB (21,168 tokens, 4.54x concurrency at `context_size` 16384) |
+| embedder weights | 16.3 GB |
+| peak free memory during indexing | ~36 GB |
+
+Memory on a DGX Spark is **unified** - the GPU and the OS draw on the same pool -
+so leaving headroom matters more than on a discrete GPU. `vllm_memory_utilization`
+is deliberately 0.5 rather than a higher value: the embedder is loaded outside
+vLLM's budget, and raising it starves the embedder and the layout detector. The
+symptom is `CUDA error: out of memory` during indexing, not at model load.
 
 To run on less memory, point `source` in `src/colette/config/vrag_default_DGX.json`
-at a smaller model of the same family and lower `context_size`.
+at a smaller model of the same family, or use `Qwen/Qwen3-VL-Embedding-2B` as the
+`embedding_model` (a smaller embedder frees memory for a larger KV cache).
 
 ### A note on ARM
 
@@ -197,11 +212,19 @@ for item in response.sources['context']:
 
 ## Notes and troubleshooting
 
-**The first run downloads ~52 GB of model weights.** Expect a long wait before
-anything appears to happen. The download is not resumable in practice — the
-Hugging Face `xet` transfer discards partial chunks if the process is
-interrupted — so let it finish. Pre-warming the cache once on a machine saves
-everyone else the wait.
+**The first run downloads ~68 GB of model weights.** ~52 GB for the generator
+plus ~16.3 GB for the embedder. Expect a long wait before anything appears to
+happen. The download is not resumable in practice — the Hugging Face `xet`
+transfer discards partial chunks if the process is interrupted — so let it
+finish. Pre-warming the cache once on a machine saves everyone else the wait.
+
+**Changing `embedding_model` invalidates every existing index.** Embeddings are
+only comparable against vectors produced by the same model, and the dimension
+usually differs too — `Qwen/Qwen3-VL-Embedding-8B` emits 4096 dimensions where
+`Alibaba-NLP/gme-Qwen2-VL-2B-Instruct` emitted 1536. ChromaDB rejects the
+mismatch rather than returning wrong results, so after switching embedders you
+must delete the app directory and reindex from scratch. Reusing an app directory
+built with a different embedder is not supported.
 
 **Run one instance at a time.** vLLM reserves `vllm_memory_utilization` of GPU
 memory up front, so two concurrent services will not fit. Two processes also
@@ -210,6 +233,22 @@ share `app_colette/`'s ChromaDB store, which surfaces as:
 ```
 InternalError: Database error: (code: 1032) attempt to write a readonly database
 ```
+
+**`CUDA error: out of memory` during indexing, after the model loaded fine.**
+The generator is not the only thing on the GPU. vLLM reserves
+`vllm_memory_utilization` up front, and the embedder (16.3 GB) plus the layout
+detector are allocated *outside* that budget, when indexing starts. So the
+failure appears minutes after a successful `service_create`. Lower
+`vllm_memory_utilization`, or switch `embedding_model` to
+`Qwen/Qwen3-VL-Embedding-2B`. Note that lowering it also shrinks the KV cache,
+which caps `context_size` — vLLM refuses to start if the cache cannot hold a
+single sequence.
+
+**`The decoder prompt (length N) is longer than the maximum model length`.**
+Hybrid retrieval sends image crops alongside text, so prompts grow quickly with
+`top_k`. The shipped `context_size` of 16384 covers the default `top_k` of 4;
+raising `top_k` may need more. Because the KV cache bounds `context_size`, going
+higher may also require a larger `vllm_memory_utilization` or a smaller embedder.
 
 **A saved app config overrides `COLETTE_VRAG_CONFIG`.** Once a service has been
 created, `<app_dir>/config.json` exists and takes precedence, so query-only

--- a/src/colette/backends/hf/layout_detector.py
+++ b/src/colette/backends/hf/layout_detector.py
@@ -14,6 +14,12 @@ class LayoutDetector:
         self.resize_height = resize_height
         self.models_repository = models_repository
         self.logger = logger
+        # device arrives as a plain int gpu id. torch.Tensor.to() reads a bare int as a
+        # CUDA index and raises "Device index must not be negative" on a negative one,
+        # so a config asking for CPU could never be honoured. Map negative ids to CPU;
+        # non-negative ids keep their previous meaning (cuda:<id>).
+        if isinstance(device, int):
+            device = torch.device("cpu") if device < 0 else torch.device(f"cuda:{device}")
         self.device = device
         self.model = self.load_model(model_path)
         self.label_map = {

--- a/src/colette/backends/hf/rag/rag_img.py
+++ b/src/colette/backends/hf/rag/rag_img.py
@@ -92,6 +92,28 @@ def get_md5sum(file_path, kvstore):
     return md5_hash.hexdigest()
 
 
+def resolve_layout_detector_gpu_id(rag_config, current):
+    """Pick the device for the layout detector when (re)indexing.
+
+    An index request rarely carries ragm settings. Overwriting unconditionally with
+    rag.gpu_id therefore discarded the layout_detector_gpu_id resolved at service
+    creation and forced the detector onto the GPU, which on a memory-tight machine
+    fails as a CUDA OOM during indexing.
+
+    Args:
+        rag_config: the rag config of the index request
+        current: the value resolved at service creation, if any
+
+    Returns: the explicit request value, else the creation-time value, else rag.gpu_id
+    """
+    requested = getattr(getattr(rag_config, "ragm", None), "layout_detector_gpu_id", None)
+    if requested is not None:
+        return requested
+    if current is not None:
+        return current
+    return rag_config.gpu_id
+
+
 def take_top_k(data: dict[str, list], k: int) -> dict[str, list]:
     """
     Extracts the first k elements from each list in the data dictionary and reverses them.
@@ -801,15 +823,9 @@ class RAGImg:
         self.rag_update_index = rag_config.update_index
         self.rag_reindex = rag_config.reindex
         self.rag_index_protection = rag_config.index_protection
-        # An index request rarely carries ragm settings, so overwriting unconditionally
-        # with rag.gpu_id discarded the layout_detector_gpu_id chosen at service creation
-        # and forced the detector onto the GPU. Only override when the request actually
-        # specifies one; otherwise keep the device resolved at creation time.
-        index_layout_gpu_id = getattr(getattr(rag_config, "ragm", None), "layout_detector_gpu_id", None)
-        if index_layout_gpu_id is not None:
-            self.rag_layout_detector_gpu_id = index_layout_gpu_id
-        elif getattr(self, "rag_layout_detector_gpu_id", None) is None:
-            self.rag_layout_detector_gpu_id = rag_config.gpu_id
+        self.rag_layout_detector_gpu_id = resolve_layout_detector_gpu_id(
+            rag_config, getattr(self, "rag_layout_detector_gpu_id", None)
+        )
 
         if self.rag_layout_detection:
             self.rag_layout_detector = LayoutDetector(

--- a/src/colette/backends/hf/rag/rag_img.py
+++ b/src/colette/backends/hf/rag/rag_img.py
@@ -300,9 +300,22 @@ class ImageEmbeddingFunction(EmbeddingFunction):
                             .eval()
                         )
                     elif "Qwen3-VL-Embedding" in self.rag_embedding_model:
+                        # Qwen3VLEmbedder forwards **kwargs to from_pretrained, which
+                        # defaults to torch.get_default_dtype() (float32) when no dtype
+                        # is given. These checkpoints ship as bfloat16, so leaving it
+                        # unset doubles resident memory (~32GB instead of ~16GB for 8B).
+                        # Match the gme-Qwen2-VL branch above and load in bfloat16.
                         embedder = Qwen3VLEmbedder(
                             model_name_or_path=self.rag_embedding_model,
                             cache_dir=str(models_repository),
+                            # resolve_attn_implementation() is called above without a
+                            # model name, so it cannot match the Qwen-VL list and returns
+                            # flash_attention_2 wherever flash-attn is installed. Qwen3-VL
+                            # uses 3D mrope and must run on sdpa; a wrong kernel here does
+                            # not crash, it silently writes garbage vectors into the index.
+                            # Resolve against the actual model name for this path.
+                            attn_implementation=resolve_attn_implementation(self.rag_embedding_model),
+                            torch_dtype=torch.bfloat16,
                         )
                         self.model = embedder.model.to("cuda:" + str(self.device)).eval()
                         self.processor = embedder.processor
@@ -788,7 +801,15 @@ class RAGImg:
         self.rag_update_index = rag_config.update_index
         self.rag_reindex = rag_config.reindex
         self.rag_index_protection = rag_config.index_protection
-        self.rag_layout_detector_gpu_id = rag_config.gpu_id
+        # An index request rarely carries ragm settings, so overwriting unconditionally
+        # with rag.gpu_id discarded the layout_detector_gpu_id chosen at service creation
+        # and forced the detector onto the GPU. Only override when the request actually
+        # specifies one; otherwise keep the device resolved at creation time.
+        index_layout_gpu_id = getattr(getattr(rag_config, "ragm", None), "layout_detector_gpu_id", None)
+        if index_layout_gpu_id is not None:
+            self.rag_layout_detector_gpu_id = index_layout_gpu_id
+        elif getattr(self, "rag_layout_detector_gpu_id", None) is None:
+            self.rag_layout_detector_gpu_id = rag_config.gpu_id
 
         if self.rag_layout_detection:
             self.rag_layout_detector = LayoutDetector(

--- a/src/colette/config/vrag_default_DGX.json
+++ b/src/colette/config/vrag_default_DGX.json
@@ -8,7 +8,7 @@
         "input": {
             "lib": "hf",
             "rag": {
-                "embedding_model": "Alibaba-NLP/gme-Qwen2-VL-2B-Instruct",
+                "embedding_model": "Qwen/Qwen3-VL-Embedding-8B",
                 "gpu_id": 0,
                 "top_k": 4,
                 "retrieval_mode": "embedding_retrieval",
@@ -29,8 +29,8 @@
         "llm": {
             "source": "Qwen/Qwen3.8-27B",
             "gpu_ids": [0],
-            "context_size": 8192,
-            "vllm_memory_utilization": 0.6,
+            "context_size": 16384,
+            "vllm_memory_utilization": 0.5,
             "image_width": 320,
             "image_height": 480,
             "adjust_aspect_ratio": true,                        

--- a/tests/test_embedding_loader.py
+++ b/tests/test_embedding_loader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 from colette.apidata import InputConnectorObj, RAGObj
 from colette.backends.hf.rag.rag_img import ImageEmbeddingFunction
@@ -25,8 +26,11 @@ def test_image_embedding_loader_monkeypatch(monkeypatch):
         def eval(self):
             return self
 
+    captured_kwargs = {}
+
     class DummyEmbedder:
         def __init__(self, *args, **kwargs):
+            captured_kwargs.update(kwargs)
             self.model = DummyModel()
             self.processor = DummyProcessor()
 
@@ -41,3 +45,14 @@ def test_image_embedding_loader_monkeypatch(monkeypatch):
     embf = ImageEmbeddingFunction(ad, Path("."), logging.getLogger())
     assert isinstance(embf.model, DummyModel)
     assert isinstance(embf.processor, DummyProcessor)
+
+    # The embedder forwards these to from_pretrained. Without an explicit dtype it
+    # falls back to torch.get_default_dtype() (float32) although the checkpoints are
+    # bfloat16, which doubles resident memory (~32GB instead of ~16GB for the 8B).
+    assert captured_kwargs.get("torch_dtype") is torch.bfloat16
+
+    # Qwen3-VL uses 3D mrope and must run on sdpa. Resolving the attention
+    # implementation without the model name returns flash_attention_2 wherever
+    # flash-attn is installed; in an embedder that does not crash, it silently
+    # writes garbage vectors into the index.
+    assert captured_kwargs.get("attn_implementation") == "sdpa"

--- a/tests/test_layout_detector_device.py
+++ b/tests/test_layout_detector_device.py
@@ -1,10 +1,12 @@
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
 
 from colette.backends.hf.layout_detector import LayoutDetector
+from colette.backends.hf.rag.rag_img import resolve_layout_detector_gpu_id
 
 
 class _DummyJitModel:
@@ -71,3 +73,44 @@ def test_layout_detector_accepts_torch_device(monkeypatch):
     )
 
     assert detector.device == torch.device("cpu")
+
+
+def _rag_config(gpu_id=0, ragm=None):
+    return SimpleNamespace(gpu_id=gpu_id, ragm=ragm)
+
+
+@pytest.mark.smoke
+def test_index_request_without_ragm_keeps_creation_time_device():
+    """The regression: an index request must not silently move the detector to the GPU.
+
+    Index requests rarely carry ragm settings. Overwriting unconditionally with
+    rag.gpu_id discarded the CPU placement resolved at service creation, which on a
+    memory-tight machine surfaces as a CUDA OOM during indexing.
+    """
+    assert resolve_layout_detector_gpu_id(_rag_config(gpu_id=0), current=-1) == -1
+
+
+@pytest.mark.smoke
+def test_index_request_ragm_without_layout_id_keeps_creation_time_device():
+    """A ragm block that omits layout_detector_gpu_id must not override either."""
+    ragm = SimpleNamespace(layout_detector_gpu_id=None)
+    assert resolve_layout_detector_gpu_id(_rag_config(gpu_id=0, ragm=ragm), current=-1) == -1
+
+
+@pytest.mark.smoke
+def test_explicit_index_request_value_wins():
+    """An explicit layout_detector_gpu_id in the index request takes precedence."""
+    ragm = SimpleNamespace(layout_detector_gpu_id=1)
+    assert resolve_layout_detector_gpu_id(_rag_config(gpu_id=0, ragm=ragm), current=-1) == 1
+
+
+@pytest.mark.smoke
+def test_falls_back_to_rag_gpu_id_when_nothing_resolved():
+    """With no request value and nothing from creation, fall back to rag.gpu_id.
+
+    This is the pre-existing behaviour for every config that does not set
+    layout_detector_gpu_id, and it must not change.
+    """
+    assert resolve_layout_detector_gpu_id(_rag_config(gpu_id=0), current=None) == 0
+    ragm = SimpleNamespace(layout_detector_gpu_id=None)
+    assert resolve_layout_detector_gpu_id(_rag_config(gpu_id=2, ragm=ragm), current=None) == 2

--- a/tests/test_layout_detector_device.py
+++ b/tests/test_layout_detector_device.py
@@ -1,0 +1,73 @@
+import logging
+from pathlib import Path
+
+import pytest
+import torch
+
+from colette.backends.hf.layout_detector import LayoutDetector
+
+
+class _DummyJitModel:
+    def __init__(self):
+        self.moved_to = None
+
+    def to(self, device):
+        self.moved_to = device
+        return self
+
+    def eval(self):
+        return self
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("gpu_id", "expected"),
+    [
+        (-1, "cpu"),
+        (0, "cuda:0"),
+        (1, "cuda:1"),
+    ],
+)
+def test_layout_detector_maps_gpu_id_to_device(monkeypatch, gpu_id, expected):
+    """A negative gpu id must select the CPU.
+
+    The device arrives as a plain int. torch reads a bare int as a CUDA index, so a
+    negative one raises "Device index must not be negative" rather than selecting the
+    CPU - meaning a config asking for CPU could never be honoured. Non-negative ids
+    must keep their previous cuda:<id> meaning.
+
+    Builds no CUDA context: torch.device() is only a descriptor and the jit model is
+    a stub, so this runs on CPU-only machines.
+    """
+    dummy = _DummyJitModel()
+    monkeypatch.setattr(torch.jit, "load", lambda _path: dummy)
+
+    detector = LayoutDetector(
+        model_path="/tmp/layout_detector_stub.pt",
+        resize_width=768,
+        resize_height=1024,
+        models_repository=Path("."),
+        logger=logging.getLogger(__name__),
+        device=gpu_id,
+    )
+
+    assert str(detector.device) == expected
+    assert str(dummy.moved_to) == expected
+
+
+@pytest.mark.smoke
+def test_layout_detector_accepts_torch_device(monkeypatch):
+    """An explicit torch.device must be passed through untouched."""
+    dummy = _DummyJitModel()
+    monkeypatch.setattr(torch.jit, "load", lambda _path: dummy)
+
+    detector = LayoutDetector(
+        model_path="/tmp/layout_detector_stub.pt",
+        resize_width=768,
+        resize_height=1024,
+        models_repository=Path("."),
+        logger=logging.getLogger(__name__),
+        device=torch.device("cpu"),
+    )
+
+    assert detector.device == torch.device("cpu")


### PR DESCRIPTION
Replaces `Alibaba-NLP/gme-Qwen2-VL-2B-Instruct` with `Qwen/Qwen3-VL-Embedding-8B`
in the DGX config, and fixes four pre-existing bugs that this exposed.

Scope is DGX only. `vrag_default.json` and `vrag_default_lite.json` are untouched.

## Four pre-existing bugs

Support for this model already existed (`qwen3_vl_embedding.py` plus a dispatch
branch in `rag_img.py`, added in d5ccd12) but had never been exercised. Running it
surfaced four defects, all present on `main` and none caused by the model swap.

**1. The embedder loaded in float32.** `Qwen3VLEmbedder` forwards `**kwargs` to
`from_pretrained`, but the call site passed no dtype, so it fell back to
`torch.get_default_dtype()` (float32) while these checkpoints ship bfloat16 —
~32 GB resident instead of ~16 GB for the 8B.

**2. The embedder ran on the wrong attention kernel.**
`resolve_attn_implementation()` is called without a model name, so the Qwen-VL
guard cannot match and it returns `flash_attention_2` wherever flash-attn is
installed. Qwen3-VL uses 3D mrope and requires `sdpa`. This one is worse in an
embedder than in a generator: a bad kernel does not produce visibly broken text,
it silently writes garbage vectors into the index.

Fixed only on the Qwen3-VL branch. The same no-arg call still affects the
gme-Qwen2-VL embedder on non-DGX machines with flash-attn installed; that is a
separate fix because it changes non-DGX behaviour.

**3. `layout_detector_gpu_id` was discarded at index time.** The index path
overwrote it with `rag.gpu_id`, throwing away the value resolved at service
creation and forcing the detector onto the GPU.

**4. A negative gpu id could never mean CPU.** The device reaches torch's `.to()`
as a bare int, which reads it as a CUDA index and raises
`Device index must not be negative`.

Bugs 3 and 4 interact: `"layout_detector_gpu_id": -1` was dead config either way,
and fixing only #3 would have turned a silent misconfiguration into a hard crash.

## Config changes

| setting | before | after | why |
|---|---|---|---|
| `embedding_model` | gme-Qwen2-VL-2B | Qwen3-VL-Embedding-8B | this PR |
| `vllm_memory_utilization` | 0.6 | 0.5 | 8B embedder costs 16.3 GB vs 8.8 GB |
| `context_size` | 8192 | 16384 | 8192 overflows on hybrid retrieval |

The `context_size` bump is **not** caused by this change. 8192 was already too
small for hybrid retrieval and was reproduced failing on the stock config at the
default `top_k` of 4, with a decoder prompt of 9040 tokens.

## Breaking: existing indexes must be rebuilt

Embedding dimension goes **1536 -> 4096**. ChromaDB rejects the mismatch rather
than returning wrong results, so any app directory built with the previous
embedder must be deleted and reindexed.

## Verification

Validated end-to-end on DGX Spark (GB10, 121 GB unified memory) against
`docs/pdf`, the example corpus used by the repo's own notebooks.

Both probe questions answer correctly, with citations checked against the source
PDF rather than taken on trust:

- "identified sources of errors" -> six sources E1-E6, page 5. `E1`-`E6` appear
  only on p5 in the PDF, and retrieval returned p5.
- "What is Colette ?" -> open-source, self-hosted, server + UI. The PDF reads
  "Serveur + UI, Open Source" and "auto-hébergés". This question was a hard
  `ValueError` at `context_size` 8192 and answers correctly at 16384.

Measured, not estimated:

| | |
|---|---|
| embedder | bfloat16, sdpa, 4096 dims, 16.3 GB resident |
| generator weights | 51.1 GiB |
| KV cache at 0.5 | 5.23 GiB (21,168 tokens, 4.54x concurrency at 16384) |
| peak pressure while indexing | 35.6 GB free, 3.8 GB swap |

Memory on a DGX Spark is unified, so an OOM starves the OS. The run was executed
under a watchdog that hard-kills the process group below 12 GB available or above
9 GB swap; it never fired.

## Tests

`test_embedding_loader.py` already covered the Qwen3-VL dispatch, but stubs
`Qwen3VLEmbedder` with a dummy that swallows `**kwargs`, so it could not have
caught bugs #1 or #2. It now asserts both kwargs explicitly.

Adds `test_layout_detector_device.py` covering the gpu-id-to-device mapping and
the index-time device resolution, and registers it in `SMOKE_TESTS`. It stubs
`torch.jit.load` and only builds `torch.device` descriptors, so it needs no GPU
and runs on CPU-only CI.

Bug #3's logic was inline in `RAGImg.index`, reachable only from an end-to-end
run, so it is extracted into `resolve_layout_detector_gpu_id()`. The extraction
was checked against the previous inline version across all 18 combinations of
`gpu_id`, `ragm` and creation-time value: 0 differences.

Each test was confirmed to fail against the pre-fix code:

    assert '-1' == 'cpu'
    assert None is torch.bfloat16

Suite: **67 passed, 3 deselected, coverage 35.48%** (was 59 / 35.18%).
No new ruff findings — per-file error counts are identical to `main`.

## Non-DGX impact: none

- `vrag_default_DGX.json` is the only config that sets `layout_detector_gpu_id`.
  Every other config leaves it `None` and falls back to `rag.gpu_id` exactly as
  before, and non-negative ids keep their `cuda:<id>` meaning.
- The dtype and attention fixes are confined to the `Qwen3-VL-Embedding` branch,
  which no other config selects.
- All RAG tests hardcode the gme embedder, so they are unaffected by the config
  change.
- `features.md` and `README.md` still cite gme-Qwen2-VL, which remains correct as
  the non-DGX default.

## Docs

`get_started_DGX_machine.md`: prerequisites raised to 96 GB memory / 140 GB disk
(two resident models, not one), download note 52 GB -> ~68 GB, KV-cache figures
replaced with measurements at 0.5, plus why that value is deliberately
conservative on unified memory. Adds troubleshooting entries for the two failures
met while validating — a CUDA OOM that appears during indexing rather than at
model load (the embedder and layout detector allocate outside vLLM's reserved
budget), and the decoder-prompt overflow — and documents that changing
`embedding_model` invalidates every existing index.